### PR TITLE
getTestAction() returns empty list when test parsing succeeds

### DIFF
--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandReportFactory.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandReportFactory.java
@@ -119,9 +119,11 @@ public class SauceOnDemandReportFactory extends Data {
 
                 if (ids.isEmpty()) {
                     logger.log(Level.WARNING, "Unable to find Sauce SessionID for test object");
-                } else {
-                    return Collections.singletonList(new SauceOnDemandReport(cr, ids, matchingJobNames));
                 }
+            }
+
+            if (!ids.isEmpty()) {
+                return Collections.singletonList(new SauceOnDemandReport(cr, ids, matchingJobNames));
             }
 
         } else {


### PR DESCRIPTION
I'm attempting to integrate my test suite with the Jenkins plugin, and while Jenkins picks up my JUnit results correctly the Sauce Labs side of things doesn't seem to be working.

I occasionally see a bunch of `INFO: Test Object not a CaseResult, unable to parse output` messages, which is weird, but more importantly at other times I see `INFO: Attempting to find Sauce SessionID for test object`.

I don't see any other messages, so based on the source code I can only assume that the standard output stream of the test does contain the correct values. However, looking at the code I noticed that it falls through to returning an empty list in every case except the one that requires hitting the REST API to retrieve the list of jobs.

I turned off my standard output to hit this code path but couldn't figure out which magic build number to use to make this REST API checking work. I think it's easier if I just submit a fix for the real issue :)

I don't have a test server to verify this fix against but it seems reasonable.
