### PR TITLE
Resolve build warnings from Maven3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
             <plugin>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-maven-plugin</artifactId>
+                <version>1.3.8</version>
                 <executions>
                     <execution>
                         <id>merge</id>


### PR DESCRIPTION
Two minor changes to resolve warnings when building with Maven 3:
1. Remove a duplicate ant dependency (scope=provided, version=1.8.0), the ant dependency with scope=test, version=1.8.1 continues to be used
2. specify version of plexus-maven-plugin as the latest released version, 1.3.8
