### PR TITLE
Add back 'platform' to SAUCE_ONDEMAND_BROWSERS.

### DIFF
--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceEnvironmentUtil.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceEnvironmentUtil.java
@@ -114,6 +114,7 @@ public class SauceEnvironmentUtil {
         JSONObject config = new JSONObject();
         try {
             config.put("os", browserInstance.getOs());
+            config.put("platform", browserInstance.getPlatform().toString());
             config.put("browser", browserInstance.getBrowserName());
             config.put("browser-version", browserInstance.getVersion());
             config.put("long-name", browserInstance.getLongName());


### PR DESCRIPTION
This was removed in 88faae777e927ec90f1548107cce72668eb0cc8b
It's a documented element of the browsers JSON.

See https://issues.jenkins-ci.org/browse/JENKINS-26117