### PR TITLE
Modified regex that accepts variables for "Sauce Host" and "Sauce Port"

### DIFF
--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
@@ -119,7 +119,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
     /**
      * Regex pattern which is used to identify replacement parameters.
      */
-    public static final Pattern ENVIRONMENT_VARIABLE_PATTERN = Pattern.compile("[$|%]([a-zA-Z_][a-zA-Z0-9_]+)");
+    public static final Pattern ENVIRONMENT_VARIABLE_PATTERN = Pattern.compile("[$|%][{]?([a-zA-Z_][a-zA-Z0-9_]+)[}]?");
     /**
      * Environment variable key which contains the browser value for the selected browser.
      */


### PR DESCRIPTION
Currently if you try to pass the standard Jenkins variable format ${varName} to Sauce Host or Sauce Port it uses the string "${varName}".  Not the value the variable contains.  The regex that determines if the text field input is a variable or not only accepts $varName.  I have modified the regex to accept both ${varName} and $varName.
![image](https://cloud.githubusercontent.com/assets/4106035/9242304/20e4904a-4134-11e5-9ab5-9dd4faa39a8f.png)
