### PR TITLE
Configurable retry feature when Sauce Connect fails to start

### DIFF
--- a/src/main/java/hudson/plugins/sauce_ondemand/PluginImpl.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/PluginImpl.java
@@ -75,6 +75,10 @@ public class PluginImpl extends Plugin implements Describable<PluginImpl> {
 
     private String sauceConnectOptions;
 
+    private String sauceConnectMaxRetries;
+
+    private String sauceConnectRetryWaitTime;
+
     @Deprecated
     private transient boolean disableStatusColumn;
 
@@ -102,6 +106,8 @@ public class PluginImpl extends Plugin implements Describable<PluginImpl> {
         sauceConnectOptions = formData.getString("sauceConnectOptions");
         environmentVariablePrefix = formData.getString("environmentVariablePrefix");
         setSendUsageData(formData.getBoolean("sendUsageData"));
+        sauceConnectMaxRetries = formData.getString("sauceConnectMaxRetries");
+        sauceConnectRetryWaitTime = formData.getString("sauceConnectRetryWaitTime");
         save();
 
     }
@@ -130,6 +136,22 @@ public class PluginImpl extends Plugin implements Describable<PluginImpl> {
 
     public void setEnvironmentVariablePrefix(String environmentVariablePrefix) {
         this.environmentVariablePrefix = environmentVariablePrefix;
+    }
+
+    public String getSauceConnectMaxRetries() {
+        return sauceConnectMaxRetries;
+    }
+
+    public void setSauceConnectMaxRetries(String sauceConnectMaxRetries) {
+        this.sauceConnectMaxRetries = sauceConnectMaxRetries;
+    }
+
+    public String getSauceConnectRetryWaitTime() {
+        return sauceConnectRetryWaitTime;
+    }
+
+    public void setSauceConnectRetryWaitTime(String sauceConnectRetryWaitTime) {
+        this.sauceConnectRetryWaitTime = sauceConnectRetryWaitTime;
     }
 
     @Deprecated

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
@@ -918,7 +918,11 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
                         } else {
                             listener.getLogger().println(String.format("Error launching Sauce Connect, trying %s time(s) more.", (maxRetries - retryCount)));
                         }
-                        wait(retryWaitTime);
+                        try {
+                            Thread.sleep(1000 * retryWaitTime);
+                        } catch (InterruptedException ie) {
+                            throw new AbstractSauceTunnelManager.SauceConnectException(ie);
+                        }
                     }
                 }
             } else {
@@ -927,13 +931,6 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
             return this;
         }
 
-        private void wait(int seconds) {
-            try {
-                Thread.sleep(1000 * seconds);
-            } catch (InterruptedException e) {
-                listener.getLogger().println(e);
-            }
-        }
     }
 
 

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
@@ -829,6 +829,8 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
         private final String workingDirectory;
         private final String username;
         private final String key;
+        private int maxRetries;
+        private int retryWaitTime;
 
         private final BuildListener listener;
         private final boolean verboseLogging;
@@ -855,6 +857,8 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
             this.verboseLogging = sauceOnDemandBuildWrapper.isVerboseLogging();
             this.sauceConnectPath = sauceOnDemandBuildWrapper.getSauceConnectPath();
             this.sauceConnectJar = sauceConnectJar;
+            this.maxRetries = 5;
+            this.retryWaitTime = 5;
         }
 
         /**
@@ -885,7 +889,6 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
             }
 
             int retryCount = 0;
-            int maxRetries = 5;
             String tempUserName = "";
             while (retryCount < maxRetries) {
                 try {
@@ -898,7 +901,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
                     } else {
                         listener.getLogger().println(String.format("Error launching Sauce Connect, trying %s time(s) more.", (maxRetries - retryCount)));
                     }
-                    wait(5);
+                    wait(retryWaitTime);
                     if (maxRetries - retryCount == 1) {
                         tempUserName = username;
                     }

--- a/src/main/resources/hudson/plugins/sauce_ondemand/PluginImpl/config.jelly
+++ b/src/main/resources/hudson/plugins/sauce_ondemand/PluginImpl/config.jelly
@@ -17,7 +17,7 @@
             <f:entry title="${%Sauce Connect Max Retries}" field="sauceConnectMaxRetries">
                 <f:textbox id="sauceConnectMaxRetriesBox"/>
             </f:entry>
-            <f:entry title="${%Sauce Connect Retry Wait Time}" field="sauceConnectRetryWaitTime">
+            <f:entry title="${%Sauce Connect Retry Wait Time in Seconds}" field="sauceConnectRetryWaitTime">
                 <f:textbox id="sauceConnectRetryWaitTimeBox"/>
             </f:entry>
             <f:entry title="${%Selenium Environment Variable Prefix}" field="environmentVariablePrefix">

--- a/src/main/resources/hudson/plugins/sauce_ondemand/PluginImpl/config.jelly
+++ b/src/main/resources/hudson/plugins/sauce_ondemand/PluginImpl/config.jelly
@@ -14,6 +14,12 @@
             <f:entry title="${%Sauce Connect Options}" field="sauceConnectOptions">
                 <f:textbox id="sauceConnectOptionsBox"/>
             </f:entry>
+            <f:entry title="${%Sauce Connect Max Retries}" field="sauceConnectMaxRetries">
+                <f:textbox id="sauceConnectMaxRetriesBox"/>
+            </f:entry>
+            <f:entry title="${%Sauce Connect Retry Wait Time}" field="sauceConnectRetryWaitTime">
+                <f:textbox id="sauceConnectRetryWaitTimeBox"/>
+            </f:entry>
             <f:entry title="${%Selenium Environment Variable Prefix}" field="environmentVariablePrefix">
                 <f:textbox id="environmentVariablePrefixBox"/>
             </f:entry>

--- a/src/main/resources/hudson/plugins/sauce_ondemand/PluginImpl/help-sauceConnectMaxRetries.html
+++ b/src/main/resources/hudson/plugins/sauce_ondemand/PluginImpl/help-sauceConnectMaxRetries.html
@@ -1,0 +1,4 @@
+<div>
+    In case Sauce Connect fails to start, specifies the number of times the plugin should attempt to launch Sauce
+    Connect again. If not set, by default, the plugin will not retry and stop at the first failure.
+</div>

--- a/src/main/resources/hudson/plugins/sauce_ondemand/PluginImpl/help-sauceConnectRetryWaitTime.html
+++ b/src/main/resources/hudson/plugins/sauce_ondemand/PluginImpl/help-sauceConnectRetryWaitTime.html
@@ -1,0 +1,5 @@
+<div>
+    In case Sauce Connect fails to start, and "Sauce Connect Max Retries" is set to a value > 0, specifies the time in
+    seconds the plugin should wait before attempting to launch Sauce Connect again. If not set, and "Sauce Connect
+    Max Retries" is set, then it defaults to 5 seconds.
+</div>

--- a/src/test/java/hudson/plugins/sauce_ondemand/ParameterizedSauceBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/ParameterizedSauceBuildWrapperTest.java
@@ -113,6 +113,8 @@ public class ParameterizedSauceBuildWrapperTest {
         pluginConfig.put("disableStatusColumn", false);
         pluginConfig.put("environmentVariablePrefix", "");
         pluginConfig.put("sendUsageData", true);
+        pluginConfig.put("sauceConnectMaxRetries", "");
+        pluginConfig.put("sauceConnectRetryWaitTime", "");
 
         sauceBuildWrapper.setCredentialId(credentialsId);
 


### PR DESCRIPTION
Hi,

This PR tries to address the issues mentioned here:
https://issues.jenkins-ci.org/browse/JENKINS-30064
https://issues.jenkins-ci.org/browse/JENKINS-33303

I have implemented this retry feature that allows the plugin to attempt to start Sauce Connect up to N times when it fails to start.
It is configurable by number of times, and number of seconds to wait between retries.
When no configuration or invalid values are provided, then it falls back to the current behaviour. 
If the number of retries is configured, but the number of seconds is not, 5 seconds are used by default.

Please review and comment if some improvements are needed. I think I touched only the necessary code.