### PR TITLE
Add option to clean up jobs/tunnels and send additional build usage data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Jenkins 1.166 - 2017-10-05
+
+* Add a new option to let the plugin close jobs and tunnels with auto-generated IDs instead of waiting for timeout, saving resources
+* If the send build usage data option is checked, some additional configuration settings will be sent for us to better gauge feature usage
+
 # Jenkins 1.165 - 2017-09-08
 
 * Updating to ci-sauce 1.129 which brings in sauce-connect 4.4.9

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,11 @@
             <version>1.4.01</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.mixpanel</groupId>
+            <artifactId>mixpanel-java</artifactId>
+            <version>1.4.4</version>
+        </dependency>
 
         <!-- Dependencies on other Jenkins plugins -->
         <dependency>

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceEnvironmentUtil.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceEnvironmentUtil.java
@@ -30,7 +30,7 @@ public final class SauceEnvironmentUtil {
     private static final Logger logger = Logger.getLogger(SauceEnvironmentUtil.class.getName());
 
     //only allow word, digit, and hyphen characters
-    private static final String PATTERN_DISALLOWED_TUNNEL_ID_CHARS = "[^\\w\\d-]+";
+    private static final String PATTERN_DISALLOWED_CHARS = "[^\\w\\d-]+";
 
     /**
      * Disallow instantiation of class.
@@ -233,12 +233,13 @@ public final class SauceEnvironmentUtil {
 
     public static String generateTunnelIdentifier(final String projectName) {
         //String rawName = build.getProject().getName();
-        String sanitizedName = projectName.replaceAll(PATTERN_DISALLOWED_TUNNEL_ID_CHARS, "_");
+        String sanitizedName = projectName.replaceAll(PATTERN_DISALLOWED_CHARS, "_");
         return sanitizedName + "-" + System.currentTimeMillis();
     }
 
+    // the buildNumber variable returned from the API uses hyphens, so we should sanitize with hyphens here
     public static String getSanitizedBuildNumber(Run run) {
-        return SauceEnvironmentUtil.getBuildName(run).replaceAll("[^A-Za-z0-9]", "_");
+        return "jenkins-"+SauceEnvironmentUtil.getBuildName(run).replaceAll(PATTERN_DISALLOWED_CHARS, "-");
     }
 
 }

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildAction.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildAction.java
@@ -97,6 +97,15 @@ public class SauceOnDemandBuildAction extends AbstractAction implements Serializ
         return jobInformation;
     }
 
+    // Get the list of running jobs and stop them all
+    public void stopJobs() {
+        SauceREST sauceREST = getSauceREST();
+        List<JenkinsJobInformation> jobs = getJobs();
+        for (JobInformation job : jobs) {
+            sauceREST.stopJob(job.getJobId());
+        }
+    }
+
     @Override
     protected SauceCredentials getCredentials() {
         if (credentialsId != null) {
@@ -153,7 +162,7 @@ public class SauceOnDemandBuildAction extends AbstractAction implements Serializ
 
         } else {
             //the list of results retrieved from the Sauce REST API is last-first, so reverse the list
-            for (int i = jobResults.length() - 1; i > 0; i--) {
+            for (int i = jobResults.length() - 1; i >= 0; i--) {
                 //check custom data to find job that was for build
                 JSONObject jobData = jobResults.getJSONObject(i);
                 String jobId = jobData.getString("id");

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
@@ -59,6 +59,10 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import com.mixpanel.mixpanelapi.ClientDelivery;
+import com.mixpanel.mixpanelapi.MessageBuilder;
+import com.mixpanel.mixpanelapi.MixpanelAPI;
+
 /**
  * {@link BuildWrapper} that sets up the Sauce OnDemand SSH tunnel and populates environment variables which
  * represent the selected browser(s).
@@ -257,7 +261,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
 
     /**
      * Constructs a new instance using data entered on the job configuration screen.
-     *  @param enableSauceConnect        indicates whether Sauce Connect should be started as part of the build.
+     * @param enableSauceConnect        indicates whether Sauce Connect should be started as part of the build.
      * @param condition                 allows users to define rules which enable Sauce Connect
      * @param seleniumInformation       the browser information that is to be used for the build.
      * @param seleniumHost              host location of the selenium server.
@@ -269,8 +273,8 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
      * @param useLatestVersion          indicates whether the latest version of the selected browser(s) should be used
      * @param forceCleanup              indicates whether to force cleanup for jobs/tunnels instead of waiting for timeout
      * @param webDriverBrowsers         which browser(s) should be used for web driver
-     * @param appiumBrowsers            which browser(s( should be used for appium
-     * @param nativeAppPackage          indicates whether the latest version of the selected browser(s) should be used
+     * @param appiumBrowsers            which browser(s) should be used for appium
+     * @param nativeAppPackage          the path to the native app package to be tested
      * @param useGeneratedTunnelIdentifier indicated whether tunnel identifers and ports should be managed by the plugin
      * @param credentialId              Which credential a build should use
      */
@@ -405,6 +409,29 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
             try {
                 logger.fine("Reporting usage data");
                 sauceREST.recordCI("jenkins", Jenkins.VERSION);
+
+                // send usage data so we know what features our customers actually use
+                try {
+                    MessageBuilder messageBuilder = new MessageBuilder("5d9a83c5f58311b7b88622d0da5e7e9d");
+                    String distinctId = username;
+                    JSONObject props = new JSONObject();
+                    props.put("plugin", "jenkins");
+                    props.put("enableSauceConnect", enableSauceConnect);
+                    props.put("verboseLogging", verboseLogging);
+                    props.put("useGeneratedTunnelIdentifier", useGeneratedTunnelIdentifier);
+                    props.put("launchSauceConnectOnSlave", launchSauceConnectOnSlave);
+                    props.put("webDriverBrowsers", webDriverBrowsers);
+                    props.put("appiumBrowsers", appiumBrowsers);
+                    props.put("useLatestVersion", useLatestVersion);
+                    props.put("forceCleanup", forceCleanup);
+                    JSONObject sentEvent = messageBuilder.event(distinctId, "Jenkins settings", props);
+                    ClientDelivery delivery = new ClientDelivery();
+                    delivery.addMessage(sentEvent);
+                    MixpanelAPI mixpanel = new MixpanelAPI();
+                    mixpanel.deliver(delivery);
+                } catch (JSONException e) {
+                    listener.getLogger().println(e);
+                }
             } catch (Exception e) {
                 logger.finest("Error reporting in: " + e.getMessage());
                 // This is purely for informational purposes, so if it fails, just keep going
@@ -562,22 +589,25 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
 
                     // stop tunnels matching the tunnel identifier
                     // this is needed as aborting during tunnel creation will prevent it from closing properly above
-                    try {
-                        String listResponse = sauceREST.getTunnels();
-                        JSONArray tunnels = new JSONArray(listResponse);
-                        for (int i = 0; i < tunnels.length(); i++) {
-                            String tunnel = tunnels.getString(i);
-                            String jsonResponse = sauceREST.getTunnelInformation(tunnel);
-                            JSONObject tunnelObj = new JSONObject(jsonResponse);
-                            if (tunnelObj.getString("tunnel_identifier").equals(tunnelIdentifier)) {
-                                listener.getLogger().println("Closing tunnel: " + tunnelObj.getString("id"));
-                                sauceREST.deleteTunnel(tunnelObj.getString("id"));
+                    if (isEnableSauceConnect() && isUseGeneratedTunnelIdentifier()) {
+                        try {
+                            String listResponse = sauceREST.getTunnels();
+                            JSONArray tunnels = new JSONArray(listResponse);
+                            for (int i = 0; i < tunnels.length(); i++) {
+                                String tunnel = tunnels.getString(i);
+                                String jsonResponse = sauceREST.getTunnelInformation(tunnel);
+                                JSONObject tunnelObj = new JSONObject(jsonResponse);
+                                if (tunnelObj.getString("tunnel_identifier").equals(tunnelIdentifier)) {
+                                    listener.getLogger().println("Closing tunnel with uniquely generated ID: " + tunnelIdentifier);
+                                    sauceREST.deleteTunnel(tunnelObj.getString("id"));
+                                }
                             }
+                        } catch (JSONException e) {
+                            listener.getLogger().println(e);
                         }
-                    } catch (JSONException e) {
-                        listener.getLogger().println(e);
+                    } else {
+                        listener.getLogger().println("Tunnel may not have a unique ID, not force closing it");
                     }
-
                     // Wait up to 5s and see if # of jobs changes, if it does, stop them again and reset wait time
                     int numJobs = jobs.size();
                     for (int waitCount = 0; waitCount < 5; waitCount++) {
@@ -590,7 +620,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
                             waitCount=-1;
                         }
                     }
-                    listener.getLogger().println("Stopped " + numJobs + " jobs");
+                    listener.getLogger().println("Stopped/completed " + numJobs + " jobs");
                 }
 
                 listener.getLogger().println("Finished post-build for Sauce Labs plugin");

--- a/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper/config.jelly
+++ b/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper/config.jelly
@@ -58,6 +58,10 @@
             <f:entry field="useLatestVersion">
                 <f:checkbox title="${%Use latest version of selected browsers}" default="checked"/>
             </f:entry>
+
+            <f:entry field="forceCleanup">
+                <f:checkbox title="${%Cleanup instead of waiting for timeouts - useful when aborting builds}"/>
+            </f:entry>
         </f:section>
         <f:section title="Sauce Connect Advanced Options">
             <f:advanced>

--- a/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper/config.jelly
+++ b/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper/config.jelly
@@ -60,7 +60,7 @@
             </f:entry>
 
             <f:entry field="forceCleanup">
-                <f:checkbox title="${%Cleanup instead of waiting for timeouts - useful when aborting builds}"/>
+                <f:checkbox title="${%Clean up jobs and uniquely generated tunnels instead of waiting for timeouts}"/>
             </f:entry>
         </f:section>
         <f:section title="Sauce Connect Advanced Options">

--- a/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper/help-forceCleanup.html
+++ b/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper/help-forceCleanup.html
@@ -1,0 +1,4 @@
+<div>
+If this checkbox is selected, it will always try to stop jobs and tunnels (if "Create a new unique Sauce Connect tunnel per build" is checked) instead of waiting for them to time out.  This is mostly useful for aborted builds.
+
+</div>

--- a/src/test/java/hudson/plugins/sauce_ondemand/ParameterizedSauceBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/ParameterizedSauceBuildWrapperTest.java
@@ -11,7 +11,6 @@ import net.sf.json.JSONObject;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
-import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
@@ -52,6 +51,7 @@ public class ParameterizedSauceBuildWrapperTest {
             boolean useGeneratedTunnelIdentifier,
             boolean verboseLogging,
             boolean useLatestVersion,
+            boolean forceCleanup,
             String seleniumPort,
             String seleniumHost
     ) throws Exception {
@@ -62,6 +62,7 @@ public class ParameterizedSauceBuildWrapperTest {
         sauceBuildWrapper.setUseGeneratedTunnelIdentifier(useGeneratedTunnelIdentifier);
         sauceBuildWrapper.setVerboseLogging(verboseLogging);
         sauceBuildWrapper.setUseLatestVersion(useLatestVersion);
+        sauceBuildWrapper.setForceCleanup(forceCleanup);
         sauceBuildWrapper.setSeleniumPort(seleniumPort);
         sauceBuildWrapper.setSeleniumHost(seleniumHost);
     }
@@ -74,17 +75,20 @@ public class ParameterizedSauceBuildWrapperTest {
                 for (boolean useGeneratedTunnelIdentifier : new boolean[]{true, false}) {
                     for (boolean verboseLogging : new boolean[]{true, false}) {
                         for (boolean useLatestVersion : new boolean[]{true, false}) {
-                            for (String seleniumPort : new String[]{"", "4444"}) {
-                                for (String seleniumHost : new String[]{"", "localhost"}) {
-                                    list.add(new Object[]{
-                                            enableSauceConnect,
-                                            launchSauceConnectOnSlave,
-                                            useGeneratedTunnelIdentifier,
-                                            verboseLogging,
-                                            useLatestVersion,
-                                            seleniumPort,
-                                            seleniumHost
-                                    });
+                            for (boolean forceCleanup : new boolean[]{false}) { // set this to {true, false} for proper testing.  But it will increase test times by about 20m
+                                 for (String seleniumPort : new String[]{"", "4444"}) {
+                                    for (String seleniumHost : new String[]{"", "localhost"}) {
+                                        list.add(new Object[]{
+                                                enableSauceConnect,
+                                                launchSauceConnectOnSlave,
+                                                useGeneratedTunnelIdentifier,
+                                                verboseLogging,
+                                                useLatestVersion,
+                                                forceCleanup,
+                                                seleniumPort,
+                                                seleniumHost
+                                        });
+                                    }
                                 }
                             }
                         }

--- a/src/test/java/hudson/plugins/sauce_ondemand/TestSauceOnDemandBuildWrapper.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/TestSauceOnDemandBuildWrapper.java
@@ -22,6 +22,7 @@ class TestSauceOnDemandBuildWrapper extends SauceOnDemandBuildWrapper {
                 false,
                 false,
                 true,
+                false,
                 null,
                 null,
                 null,


### PR DESCRIPTION
1. The option can save resources by not waiting for timeouts
2. Additional configuration data is sent when enabled so we can better gauge feature usage in the plugin