### PR TITLE
Add option pipeline generator to use latest Sauce Connect.

### DIFF
--- a/src/main/resources/com/saucelabs/jenkins/pipeline/SauceConnectStep/config.jelly
+++ b/src/main/resources/com/saucelabs/jenkins/pipeline/SauceConnectStep/config.jelly
@@ -10,6 +10,11 @@
     <f:entry field="useGeneratedTunnelIdentifier">
         <f:checkbox title="${%Create a new unique Sauce Connect tunnel per build}"/>
     </f:entry>
+    <f:entry field="useLatestSauceConnect"
+        title="${%Download and the latest version of Sauce Connect}"
+        description="Leave blank to used the bundled version">
+        <f:checkbox/>
+    </f:entry>
 
     <f:entry field="sauceConnectPath"
         title="${%Sauce Connect Binary Location}"


### PR DESCRIPTION
The option to use the latest version of Sauce Connect is present in the code, but the template to generate the Pipeline script itself omitted it.

This changes causes it to be included.