### PR TITLE
Allow Pipeline to use the latest Sauce Connect

### DIFF
--- a/src/main/java/com/saucelabs/jenkins/pipeline/SauceConnectStep.java
+++ b/src/main/java/com/saucelabs/jenkins/pipeline/SauceConnectStep.java
@@ -138,20 +138,23 @@ public class SauceConnectStep extends AbstractStepImpl {
         private final TaskListener listener;
         private final Boolean verboseLogging;
         private final String sauceConnectPath;
+        private final Boolean useLatestSauceConnect;
 
-        SauceStartConnectHandler(SauceCredentials sauceCredentials, int port, String options, TaskListener listener, Boolean verboseLogging, String sauceConnectPath) {
+        SauceStartConnectHandler(SauceCredentials sauceCredentials, int port, String options, TaskListener listener, Boolean verboseLogging, String sauceConnectPath, Boolean useLatestSauceConnect) {
             this.sauceCredentials = sauceCredentials;
             this.port = port;
             this.options = options;
             this.listener = listener;
             this.verboseLogging = verboseLogging;
             this.sauceConnectPath = sauceConnectPath;
+            this.useLatestSauceConnect = useLatestSauceConnect;
         }
 
         @Override
         public Void call() throws AbstractSauceTunnelManager.SauceConnectException {
             SauceConnectFourManager sauceTunnelManager = getSauceTunnelManager();
             sauceTunnelManager.setSauceRest(sauceCredentials.getSauceREST());
+            sauceTunnelManager.setUseLatestSauceConnect(useLatestSauceConnect);
             sauceTunnelManager.openConnection(
                 sauceCredentials.getUsername(),
                 sauceCredentials.getApiKey().getPlainText(),
@@ -241,7 +244,8 @@ public class SauceConnectStep extends AbstractStepImpl {
                 options,
                 listener,
                 step.getVerboseLogging(),
-                step.getSauceConnectPath()
+                step.getSauceConnectPath(),
+                step.getUseLatestSauceConnect()
             );
             computer.getChannel().call(handler);
 

--- a/src/main/resources/com/saucelabs/jenkins/pipeline/SauceConnectStep/config.jelly
+++ b/src/main/resources/com/saucelabs/jenkins/pipeline/SauceConnectStep/config.jelly
@@ -10,6 +10,11 @@
     <f:entry field="useGeneratedTunnelIdentifier">
         <f:checkbox title="${%Create a new unique Sauce Connect tunnel per build}"/>
     </f:entry>
+    <f:entry field="useLatestSauceConnect"
+        title="${%Download and the latest version of Sauce Connect}"
+        description="Leave blank to used the bundled version">
+        <f:checkbox/>
+    </f:entry>
 
     <f:entry field="sauceConnectPath"
         title="${%Sauce Connect Binary Location}"


### PR DESCRIPTION
Currently, the standard version of the Jenkins plugin allows users to choose to download latest Sauce Connect version.

The option is _present_ in Pipeline, but was not rendered in the script generator nor was its value passed to the underlying Manager.

This change implements those two parts.