### PR TITLE
Don't show secret to the user

### DIFF
--- a/src/main/resources/hudson/plugins/sauce_ondemand/credentials/SauceCredentials/credentials.jelly
+++ b/src/main/resources/hudson/plugins/sauce_ondemand/credentials/SauceCredentials/credentials.jelly
@@ -4,7 +4,7 @@
         <f:textbox/>
     </f:entry>
     <f:entry title="${%Access Key}" field="apiKey">
-        <f:textbox/>
+        <f:password/>
     </f:entry>
     <f:entry title="${%Sauce Data Center}" name="restEndpoint" field="restEndpoint">
         <select name="restEndpoint">


### PR DESCRIPTION
Secrets shouldn't be shown back to the user, I was just asked to update our prod credentials and was very surprised to see the secret there in plain text

Implementation guide for plugins is here:
https://github.com/jenkinsci/credentials-plugin/blob/master/docs/implementation.adoc
Search jelly to see how it should be setup