### PR TITLE
Reduced Sauce build retrieve timeout (100s -> 3s)

### DIFF
--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildAction.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildAction.java
@@ -152,8 +152,15 @@ public class SauceOnDemandBuildAction extends AbstractAction implements Serializ
 
         logger.fine("Performing Sauce REST retrieve results for " + buildNumber);
 
+        // A note on retry behaviour
+        // This code was previously set to retry 10 times with 10 seconds pause in between - this resulted
+        // in de-facto hang behaviour in Jenkins on the status pages of builds if an error occurrec, which
+        // meant either that the page took over 100 seconds to load, or that the connection was killed by
+        // a downstream proxy (e.g. an ELB) which had a connection timeout below 100 seconds. It has been
+        // updated to retry one time with a 3 second pause to allow for recovery from brief blips while
+        // not stalling page load for more than a few seconds to ensure a good user experience.
         int retries = 0;
-        int maxRetries = 10;
+        int maxRetries = 1;
         String jsonResponse = "";
 
         while (retries < maxRetries && "".equals(jsonResponse)) {
@@ -170,7 +177,7 @@ public class SauceOnDemandBuildAction extends AbstractAction implements Serializ
             logger.log(Level.WARNING, "Sauce REST API get build JSON Response was empty or threw an exception for " + buildNumber + ", waiting and retrying");
             retries++;
             try {
-                Thread.sleep(10000);
+                Thread.sleep(3000);
             } catch (InterruptedException e) {
             }
         }

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildAction.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildAction.java
@@ -154,7 +154,7 @@ public class SauceOnDemandBuildAction extends AbstractAction implements Serializ
 
         // A note on retry behaviour
         // This code was previously set to retry 10 times with 10 seconds pause in between - this resulted
-        // in de-facto hang behaviour in Jenkins on the status pages of builds if an error occurrec, which
+        // in de-facto hang behaviour in Jenkins on the status pages of builds if an error occurred, which
         // meant either that the page took over 100 seconds to load, or that the connection was killed by
         // a downstream proxy (e.g. an ELB) which had a connection timeout below 100 seconds. It has been
         // updated to retry one time with a 3 second pause to allow for recovery from brief blips while


### PR DESCRIPTION
This code was previously set to retry 10 times with 10 seconds pause in between - this resulted
in de-facto hang behaviour in Jenkins on the status pages of builds if an error occurred, which
meant either that the page took over 100 seconds to load, or that the connection was killed by
a downstream proxy (e.g. an ELB) which had a connection timeout below 100 seconds. It has been
updated to retry one time with a 3 second pause to allow for recovery from brief blips while
not stalling page load for more than a few seconds to ensure a good user experience.