### PR TITLE
Fix sauce connect command line generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Jenkins 1.188 - 2020-05-27
+
+* Fix command line handling for Sauce Connect v4.6+
+* CI/CD pipeline fixes
+
 # Jenkins 1.187 - 2019-11-07
 
 * Reduce build fetch retry to once after 3 seconds to improve user experience

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <parent>
         <groupId>org.jenkins-ci.plugins</groupId>
         <artifactId>plugin</artifactId>
-        <version>2.11</version>
+        <version>2.23</version>
         <relativePath />
     </parent>
     <properties>
@@ -294,6 +294,7 @@
             <artifactId>symbol-annotation</artifactId>
             <version>1.1</version>
         </dependency>
+
     </dependencies>
     <repositories>
         <repository>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <plugins.run-condition.version>1.0</plugins.run-condition.version>
         <plugins.junit.version>1.21</plugins.junit.version>
         <plugins.workflow.version>1.15</plugins.workflow.version>
-        <ci-sauce.version>1.142</ci-sauce.version>
+        <ci-sauce.version>1.145</ci-sauce.version>
         <saucerest.version>1.0.42</saucerest.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0-M4</version>
+                <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
+                </configuration>
             </plugin>
 
 			<plugin>

--- a/src/test/resources/pom.xml
+++ b/src/test/resources/pom.xml
@@ -1,8 +1,32 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-  <modelVersion>4.0.0</modelVersion>
-  <groupId>test</groupId>
-  <artifactId>test</artifactId>
-  <version>0.1-SNAPSHOT</version>
-  <packaging>jar</packaging>
-</project>
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>test</groupId>
+    <artifactId>test</artifactId>
+    <version>0.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
 
+    <pluginRepositories>
+        <pluginRepository>
+            <id>central</id>
+            <url>https://repo.maven.apache.org/maven2</url>
+            <layout>default</layout>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+        </pluginRepository>
+        <pluginRepository>
+            <id>central2</id>
+            <url>https://repo1.maven.org/maven2</url>
+            <layout>default</layout>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <releases>
+                <updatePolicy>never</updatePolicy>
+            </releases>
+        </pluginRepository>
+    </pluginRepositories>
+</project>


### PR DESCRIPTION
Sauce Connect 4.6+ has stricter command line parsing. Update the ci-sauce module to fix this.