### PR TITLE
Update ci-sauce to 1.146 (with Sauce Connect 4.6.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Jenkins 1.189 - 2020-06-01
+
+* Update ci-sauce to 1.146 (with Sauce Connect 4.6.2)
+
 # Jenkins 1.188 - 2020-05-27
 
 * Fix command line handling for Sauce Connect v4.6+

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
         <plugins.run-condition.version>1.0</plugins.run-condition.version>
         <plugins.junit.version>1.21</plugins.junit.version>
         <plugins.workflow.version>1.15</plugins.workflow.version>
-        <ci-sauce.version>1.145</ci-sauce.version>
+        <ci-sauce.version>1.146</ci-sauce.version>
         <saucerest.version>1.0.42</saucerest.version>
     </properties>
 


### PR DESCRIPTION
Sauce Connect 4.6.2 has been released