### PR TITLE
Prepare for sunset icon removal from core

### DIFF
--- a/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandProjectAction/index.jelly
+++ b/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandProjectAction/index.jelly
@@ -27,7 +27,7 @@ THE SOFTWARE.
          xmlns:l="/lib/layout">
   <l:layout title="Video and Server Log - ${it.parent.displayName}">
     <l:side-panel>
-      <l:task href=".." title="${%Back}" icon="images/24x24/up.gif" />
+      <l:task href=".." title="${%Back}" icon="icon-up icon-md" />
     </l:side-panel>
     <l:main-panel>
       <h1>Sauce OnDemand Reports</h1>

--- a/src/main/resources/hudson/plugins/sauce_ondemand/SauceTestResultsById/index.jelly
+++ b/src/main/resources/hudson/plugins/sauce_ondemand/SauceTestResultsById/index.jelly
@@ -26,7 +26,7 @@ THE SOFTWARE.
          xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
   <l:layout title="Sauce OnDemand Report">
     <l:side-panel>
-      <l:task href=".." title="${%Back To Build}" icon="images/24x24/up.gif" />
+      <l:task href=".." title="${%Back To Build}" icon="icon-up icon-md" />
     </l:side-panel>
     <l:main-panel>
       <h1><a href="${it.server}tests/${it.id}">Sauce OnDemand Report for ${it.id}</a></h1>


### PR DESCRIPTION
Preparation for core sunsetting dated icons: `https://github.com/jenkinsci/jenkins/pull/5778/`

@sauce-jenkins-bot or @alexh-sauce Would be nice if you can also trigger a release after merging this PR. The core PR is blocked until then.
Thanks in advance!