### PR TITLE
Use tunnel-name instead of tunnel-identifier

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <dependency>
             <groupId>com.auth0</groupId>
             <artifactId>java-jwt</artifactId>
-            <version>3.1.0</version>
+            <version>3.18.1</version>
             <exclusions>
                 <!-- provided by jackson2 api plugin -->
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <!-- Java Level to use. Java 7 required when using core >= 1.612 -->
         <java.level>8</java.level>
         <plugins.run-condition.version>1.0</plugins.run-condition.version>
-        <ci-sauce.version>1.155</ci-sauce.version>
+        <ci-sauce.version>1.156</ci-sauce.version>
         <saucerest.version>1.1.2</saucerest.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.level>8</java.level>
         <plugins.run-condition.version>1.0</plugins.run-condition.version>
         <ci-sauce.version>1.156</ci-sauce.version>
-        <saucerest.version>1.1.2</saucerest.version>
+        <saucerest.version>1.1.7</saucerest.version>
     </properties>
 
 
@@ -134,7 +134,7 @@
         <dependency>
             <groupId>com.mixpanel</groupId>
             <artifactId>mixpanel-java</artifactId>
-            <version>1.4.4</version>
+            <version>1.5.0</version>
         </dependency>
 
         <!-- Dependencies on other Jenkins plugins -->
@@ -286,7 +286,7 @@
         <dependency>
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
-            <version>20211205</version>
+            <version>20220320</version>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -299,7 +299,7 @@
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>3.6.0</version>
+            <version>3.8.0</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <java.level>8</java.level>
         <plugins.run-condition.version>1.0</plugins.run-condition.version>
         <ci-sauce.version>1.156</ci-sauce.version>
-        <saucerest.version>1.1.7</saucerest.version>
+        <saucerest.version>1.1.8</saucerest.version>
     </properties>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -273,7 +273,7 @@
         <dependency>
             <groupId>org.apache.maven.shared</groupId>
             <artifactId>maven-shared-utils</artifactId>
-            <version>3.2.1</version>
+            <version>3.3.4</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -260,7 +260,7 @@
         <dependency>
             <groupId>commons-fileupload</groupId>
             <artifactId>commons-fileupload</artifactId>
-            <version>1.3.1-jenkins-2</version>
+            <version>1.3.3</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>

--- a/src/main/java/com/saucelabs/jenkins/pipeline/SauceConnectStep.java
+++ b/src/main/java/com/saucelabs/jenkins/pipeline/SauceConnectStep.java
@@ -269,7 +269,7 @@ public class SauceConnectStep extends Step {
             if (useGeneratedTunnelIdentifier) {
                 final String tunnelIdentifier = SauceEnvironmentUtil.generateTunnelIdentifier(job.getName());
                 overrides.put(SauceOnDemandBuildWrapper.TUNNEL_IDENTIFIER, tunnelIdentifier);
-                options = options + " --tunnel-identifier " + tunnelIdentifier;
+                options = options + " --tunnel-name " + tunnelIdentifier;
 
             }
 

--- a/src/main/java/com/saucelabs/jenkins/pipeline/SauceConnectStep.java
+++ b/src/main/java/com/saucelabs/jenkins/pipeline/SauceConnectStep.java
@@ -43,7 +43,7 @@ import static com.saucelabs.jenkins.pipeline.SauceConnectStep.SauceConnectStepEx
 public class SauceConnectStep extends Step {
     private Boolean verboseLogging = false;
     private Boolean useLatestSauceConnect = false;
-    private Boolean useGeneratedTunnelIdentifier = false;
+    private Boolean useGeneratedTunnelName = false;
     private String options;
     private String sauceConnectPath;
 
@@ -51,10 +51,10 @@ public class SauceConnectStep extends Step {
     public SauceConnectStep() {
     }
 
-    public SauceConnectStep(String options, Boolean verboseLogging, Boolean useLatestSauceConnect, Boolean useGeneratedTunnelIdentifier, String sauceConnectPath) {
+    public SauceConnectStep(String options, Boolean verboseLogging, Boolean useLatestSauceConnect, Boolean useGeneratedTunnelName, String sauceConnectPath) {
         this.verboseLogging = verboseLogging;
         this.useLatestSauceConnect = useLatestSauceConnect;
-        this.useGeneratedTunnelIdentifier = useGeneratedTunnelIdentifier;
+        this.useGeneratedTunnelName = useGeneratedTunnelName;
         this.sauceConnectPath = Util.fixEmptyAndTrim(sauceConnectPath);
         this.options = StringUtils.trimToEmpty(options);
     }
@@ -64,7 +64,7 @@ public class SauceConnectStep extends Step {
         return new SauceConnectStepExecution(context,
             PluginImpl.get().getSauceConnectOptions(),
             options,
-            useGeneratedTunnelIdentifier,
+            useGeneratedTunnelName,
             verboseLogging,
             sauceConnectPath,
             useLatestSauceConnect
@@ -90,13 +90,13 @@ public class SauceConnectStep extends Step {
         this.sauceConnectPath = sauceConnectPath;
     }
 
-    public Boolean getUseGeneratedTunnelIdentifier() {
-        return useGeneratedTunnelIdentifier;
+    public Boolean getUseGeneratedTunnelName() {
+        return useGeneratedTunnelName;
     }
 
     @DataBoundSetter
-    public void setUseGeneratedTunnelIdentifier(Boolean useGeneratedTunnelIdentifier) {
-        this.useGeneratedTunnelIdentifier = useGeneratedTunnelIdentifier;
+    public void setUseGeneratedTunnelName(Boolean useGeneratedTunnelName) {
+        this.useGeneratedTunnelName = useGeneratedTunnelName;
     }
 
     public Boolean getUseLatestSauceConnect() {
@@ -211,7 +211,7 @@ public class SauceConnectStep extends Step {
     public static class SauceConnectStepExecution extends StepExecution {
         private final String globalOptions;
         private final String options;
-        private final boolean useGeneratedTunnelIdentifier;
+        private final boolean useGeneratedTunnelName;
         private final boolean verboseLogging;
         private final String sauceConnectPath;
         private final boolean useLatestSauceConnect;
@@ -224,7 +224,7 @@ public class SauceConnectStep extends Step {
             @Nonnull StepContext context,
             String globalOptions,
             String options,
-            boolean useGeneratedTunnelIdentifier,
+            boolean useGeneratedTunnelName,
             boolean verboseLogging,
             String sauceConnectPath,
             boolean useLatestSauceConnect
@@ -232,7 +232,7 @@ public class SauceConnectStep extends Step {
             super(context);
             this.globalOptions = globalOptions;
             this.options = options;
-            this.useGeneratedTunnelIdentifier = useGeneratedTunnelIdentifier;
+            this.useGeneratedTunnelName = useGeneratedTunnelName;
             this.verboseLogging = verboseLogging;
             this.sauceConnectPath = sauceConnectPath;
             this.useLatestSauceConnect = useLatestSauceConnect;
@@ -266,10 +266,10 @@ public class SauceConnectStep extends Step {
             overrides.put(SauceOnDemandBuildWrapper.SELENIUM_PORT, String.valueOf(port));
             overrides.put(SauceOnDemandBuildWrapper.SELENIUM_HOST, "localhost");
 
-            if (useGeneratedTunnelIdentifier) {
-                final String tunnelIdentifier = SauceEnvironmentUtil.generateTunnelIdentifier(job.getName());
-                overrides.put(SauceOnDemandBuildWrapper.TUNNEL_IDENTIFIER, tunnelIdentifier);
-                options = options + " --tunnel-name " + tunnelIdentifier;
+            if (useGeneratedTunnelName) {
+                final String tunnelName = SauceEnvironmentUtil.generateTunnelName(job.getName());
+                overrides.put(SauceOnDemandBuildWrapper.TUNNEL_NAME, tunnelName);
+                options = options + " --tunnel-name " + tunnelName;
 
             }
 

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceEnvironmentUtil.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceEnvironmentUtil.java
@@ -231,7 +231,7 @@ public final class SauceEnvironmentUtil {
         return builder.toString();
     }
 
-    public static String generateTunnelIdentifier(final String projectName) {
+    public static String generateTunnelName(final String projectName) {
         //String rawName = build.getProject().getName();
         String sanitizedName = projectName.replaceAll(PATTERN_DISALLOWED_CHARS, "_");
         return sanitizedName + "-" + System.currentTimeMillis();

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
@@ -367,7 +367,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
 
             if (isUseGeneratedTunnelIdentifier()) {
                 build.getBuildVariables().put(TUNNEL_IDENTIFIER, tunnelIdentifier);
-                resolvedOptions = resolvedOptions + " --tunnel-identifier " + tunnelIdentifier;
+                resolvedOptions = resolvedOptions + " --tunnel-name " + tunnelIdentifier;
             }
 
             build.getBuildVariables().put(SAUCE_REST_ENDPOINT, restEndpoint);
@@ -403,11 +403,11 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
                 );
 
                 if (launchSauceConnectOnSlave) {
-                    listener.getLogger().println("Starting Sauce Connect on slave node using tunnel identifier: " + AbstractSauceTunnelManager.getTunnelIdentifier(resolvedOptions, "default"));
+                    listener.getLogger().println("Starting Sauce Connect on slave node using tunnel identifier: " + AbstractSauceTunnelManager.getTunnelName(resolvedOptions, "default"));
                     Computer.currentComputer().getChannel().call(sauceConnectStarter);
 
                 } else {
-                    listener.getLogger().println("Starting Sauce Connect on master node using identifier: " + AbstractSauceTunnelManager.getTunnelIdentifier(resolvedOptions, "default"));
+                    listener.getLogger().println("Starting Sauce Connect on master node using identifier: " + AbstractSauceTunnelManager.getTunnelName(resolvedOptions, "default"));
                     //launch Sauce Connect on the master
                     sauceConnectStarter.call();
 
@@ -582,7 +582,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
 
                         if (isUseGeneratedTunnelIdentifier()) {
                             build.getBuildVariables().put(TUNNEL_IDENTIFIER, tunnelIdentifier);
-                            resolvedOptions = "--tunnel-identifier " + tunnelIdentifier + " " + resolvedOptions;
+                            resolvedOptions = "--tunnel-name " + tunnelIdentifier + " " + resolvedOptions;
                         }
 
                         if (launchSauceConnectOnSlave) {

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
@@ -160,7 +160,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
 
     public static final String USE_LATEST_SAUCE_CONNECT = "USE_LATEST_SAUCE_CONNECT";
 
-    public static final String TUNNEL_IDENTIFIER = "TUNNEL_IDENTIFIER";
+    public static final String TUNNEL_NAME = "TUNNEL_NAME";
 
     /**
      * Environment variable key which contains the native app path.
@@ -172,7 +172,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
      */
     private static final String SAUCE_USE_CHROME = "SAUCE_USE_CHROME";
 
-    private boolean useGeneratedTunnelIdentifier;
+    private boolean useGeneratedTunnelName;
 
     private static final long serialVersionUID = 1L;
     /**
@@ -286,7 +286,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
      * @param webDriverBrowsers         which browser(s) should be used for web driver
      * @param appiumBrowsers            which browser(s) should be used for appium
      * @param nativeAppPackage          the path to the native app package to be tested
-     * @param useGeneratedTunnelIdentifier indicated whether tunnel identifers and ports should be managed by the plugin
+     * @param useGeneratedTunnelName    indicated whether tunnel names and ports should be managed by the plugin
      * @param credentialId              Which credential a build should use
      */
     @DataBoundConstructor
@@ -308,7 +308,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
         List<String> appiumBrowsers,
         String nativeAppPackage,
 //            boolean useChromeForAndroid,
-        boolean useGeneratedTunnelIdentifier
+        boolean useGeneratedTunnelName
     ) {
         this.seleniumInformation = seleniumInformation;
         this.enableSauceConnect = enableSauceConnect;
@@ -330,7 +330,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
         this.sauceConnectPath = sauceConnectPath;
         this.nativeAppPackage = nativeAppPackage;
 //        this.useChromeForAndroid = useChromeForAndroid;
-        this.useGeneratedTunnelIdentifier = useGeneratedTunnelIdentifier;
+        this.useGeneratedTunnelName = useGeneratedTunnelName;
         this.credentialId = credentialId;
     }
 
@@ -355,7 +355,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
         final String username = credentials.getUsername();
         final String restEndpoint = credentials.getRestEndpoint();
 
-        final String tunnelIdentifier = SauceEnvironmentUtil.generateTunnelIdentifier(build.getProject().getName());
+        final String tunnelName = SauceEnvironmentUtil.generateTunnelName(build.getProject().getName());
         final SauceConnectHandler sauceConnectStarter;
         if (isEnableSauceConnect()) {
 
@@ -365,9 +365,9 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
             String retryWaitTime = p != null ? p.getSauceConnectRetryWaitTime() : null;
             String resolvedOptions = getCommandLineOptions(build, listener);
 
-            if (isUseGeneratedTunnelIdentifier()) {
-                build.getBuildVariables().put(TUNNEL_IDENTIFIER, tunnelIdentifier);
-                resolvedOptions = resolvedOptions + " --tunnel-name " + tunnelIdentifier;
+            if (isUseGeneratedTunnelName()) {
+                build.getBuildVariables().put(TUNNEL_NAME, tunnelName);
+                resolvedOptions = resolvedOptions + " --tunnel-name " + tunnelName;
             }
 
             build.getBuildVariables().put(SAUCE_REST_ENDPOINT, restEndpoint);
@@ -403,7 +403,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
                 );
 
                 if (launchSauceConnectOnSlave) {
-                    listener.getLogger().println("Starting Sauce Connect on slave node using tunnel identifier: " + AbstractSauceTunnelManager.getTunnelName(resolvedOptions, "default"));
+                    listener.getLogger().println("Starting Sauce Connect on slave node using tunnel name: " + AbstractSauceTunnelManager.getTunnelName(resolvedOptions, "default"));
                     Computer.currentComputer().getChannel().call(sauceConnectStarter);
 
                 } else {
@@ -435,7 +435,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
                     props.put("plugin", "jenkins");
                     props.put("enableSauceConnect", enableSauceConnect);
                     props.put("verboseLogging", verboseLogging);
-                    props.put("useGeneratedTunnelIdentifier", useGeneratedTunnelIdentifier);
+                    props.put("useGeneratedTunnelName", useGeneratedTunnelName);
                     props.put("launchSauceConnectOnSlave", launchSauceConnectOnSlave);
                     props.put("webDriverBrowsers", webDriverBrowsers);
                     props.put("appiumBrowsers", appiumBrowsers);
@@ -521,8 +521,8 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
                     SauceEnvironmentUtil.outputEnvironmentVariable(env, SAUCE_NATIVE_APP, getNativeAppPackage(), true, verboseLogging, listener.getLogger());
                 }
 
-                if (isEnableSauceConnect() && isUseGeneratedTunnelIdentifier()) {
-                    SauceEnvironmentUtil.outputEnvironmentVariable(env, TUNNEL_IDENTIFIER, tunnelIdentifier, true, verboseLogging, listener.getLogger());
+                if (isEnableSauceConnect() && isUseGeneratedTunnelName()) {
+                    SauceEnvironmentUtil.outputEnvironmentVariable(env, TUNNEL_NAME, tunnelName, true, verboseLogging, listener.getLogger());
                 }
 
                 SauceEnvironmentUtil.outputEnvironmentVariable(env, SAUCE_USE_CHROME, String.valueOf(isUseChromeForAndroid()), true, verboseLogging, listener.getLogger());
@@ -580,9 +580,9 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
                         listener.getLogger().println("Shutting down Sauce Connect");
                         String resolvedOptions = getCommandLineOptions(build, listener);
 
-                        if (isUseGeneratedTunnelIdentifier()) {
-                            build.getBuildVariables().put(TUNNEL_IDENTIFIER, tunnelIdentifier);
-                            resolvedOptions = "--tunnel-name " + tunnelIdentifier + " " + resolvedOptions;
+                        if (isUseGeneratedTunnelName()) {
+                            build.getBuildVariables().put(TUNNEL_NAME, tunnelName);
+                            resolvedOptions = "--tunnel-name " + tunnelName + " " + resolvedOptions;
                         }
 
                         if (launchSauceConnectOnSlave) {
@@ -606,11 +606,11 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
                     buildAction = new SauceOnDemandBuildAction(build, SauceOnDemandBuildWrapper.this.credentialId);
                     buildAction.stopJobs();
 
-                    // stop tunnels matching the tunnel identifier
+                    // stop tunnels matching the tunnel name
                     // this is needed as aborting during tunnel creation will prevent it from closing properly above
                     SauceCredentials credentials = SauceCredentials.getSauceCredentials(build, SauceOnDemandBuildWrapper.this); // get credentials
                     JenkinsSauceREST sauceREST = credentials.getSauceREST(); // use credentials to get sauceRest
-                    if (isEnableSauceConnect() && isUseGeneratedTunnelIdentifier()) {
+                    if (isEnableSauceConnect() && isUseGeneratedTunnelName()) {
                         try {
                             String listResponse = sauceREST.getTunnels();
                             JSONArray tunnels = new JSONArray(listResponse);
@@ -618,8 +618,8 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
                                 String tunnel = tunnels.getString(i);
                                 String jsonResponse = sauceREST.getTunnelInformation(tunnel);
                                 JSONObject tunnelObj = new JSONObject(jsonResponse);
-                                if (tunnelObj.getString("tunnel_identifier").equals(tunnelIdentifier)) {
-                                    listener.getLogger().println("Closing tunnel with uniquely generated ID: " + tunnelIdentifier);
+                                if (tunnelObj.getString("tunnel_identifier").equals(tunnelName)) {
+                                    listener.getLogger().println("Closing tunnel with uniquely generated ID: " + tunnelName);
                                     sauceREST.deleteTunnel(tunnelObj.getString("id"));
                                 }
                             }
@@ -774,7 +774,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
             }
         } else {
             if (isEnableSauceConnect()) {
-                if (isUseGeneratedTunnelIdentifier()) {
+                if (isUseGeneratedTunnelName()) {
                     try {
                         if (launchSauceConnectOnSlave) {
                             return Computer.currentComputer().getChannel().call(new GetAvailablePort());
@@ -867,12 +867,12 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
         this.useLatestSauceConnect = useLatestSauceConnect;
     }
 
-    public boolean isUseGeneratedTunnelIdentifier() {
-        return useGeneratedTunnelIdentifier;
+    public boolean isUseGeneratedTunnelName() {
+        return useGeneratedTunnelName;
     }
 
-    public void setUseGeneratedTunnelIdentifier(boolean useGeneratedTunnelIdentifier) {
-        this.useGeneratedTunnelIdentifier = useGeneratedTunnelIdentifier;
+    public void setUseGeneratedTunnelName(boolean useGeneratedTunnelName) {
+        this.useGeneratedTunnelName = useGeneratedTunnelName;
     }
 
     public boolean isVerboseLogging() {

--- a/src/main/java/hudson/plugins/sauce_ondemand/credentials/SauceCredentials.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/credentials/SauceCredentials.java
@@ -119,8 +119,6 @@ public class SauceCredentials extends BaseStandardCredentials implements Standar
             } catch (JWTCreationException e){
                 //Invalid Signing configuration / Couldn't convert Claims.
                 e.printStackTrace();
-            } catch (UnsupportedEncodingException e) {
-                e.printStackTrace();
             }
         }
         return this.getApiKey();

--- a/src/main/resources/com/saucelabs/jenkins/pipeline/SauceConnectStep/config.jelly
+++ b/src/main/resources/com/saucelabs/jenkins/pipeline/SauceConnectStep/config.jelly
@@ -7,7 +7,7 @@
     <f:entry field="options" title="${%Sauce Connect Options}">
         <f:textbox/>
     </f:entry>
-    <f:entry field="useGeneratedTunnelIdentifier">
+    <f:entry field="useGeneratedTunnelName">
         <f:checkbox title="${%Create a new unique Sauce Connect tunnel per build}"/>
     </f:entry>
     <f:entry field="useLatestSauceConnect"

--- a/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper/config.jelly
+++ b/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper/config.jelly
@@ -89,7 +89,7 @@
                 <f:entry title="${%Sauce Connect Options}" field="options">
                     <f:textbox/>
                 </f:entry>
-                <f:entry field="useGeneratedTunnelIdentifier">
+                <f:entry field="useGeneratedTunnelName">
                     <f:checkbox title="${%Create a new unique Sauce Connect tunnel per build}"/>
                 </f:entry>
 

--- a/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper/help-useGeneratedTunnelIdentifier.html
+++ b/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper/help-useGeneratedTunnelIdentifier.html
@@ -1,8 +1,0 @@
-<!DOCTYPE html>
-<div>
-    Generate a tunnel identifier of the form: &lt;project name&gt;-&lt;current epoch time in milliseconds&gt;
-    <br/>
-    Allocates available random port every build and sets the SELENIUM_PORT environment variable.
-    <br />
-    The value of the tunnel identifier will be stored in the TUNNEL_IDENTIFIER environment variable.
-</div>

--- a/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper/help-useGeneratedTunnelName.html
+++ b/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper/help-useGeneratedTunnelName.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<div>
+    Generate a tunnel name of the form: &lt;project name&gt;-&lt;current epoch time in milliseconds&gt;
+    <br/>
+    Allocates available random port every build and sets the SELENIUM_PORT environment variable.
+    <br />
+    The value of the tunnel name will be stored in the TUNNEL_NAME environment variable.
+</div>

--- a/src/test/java/com/saucelabs/jenkins/pipeline/SauceStepTest.java
+++ b/src/test/java/com/saucelabs/jenkins/pipeline/SauceStepTest.java
@@ -108,7 +108,7 @@ public class SauceStepTest {
 
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "SauceStepTest-sauceConnectWithGlobalOptionsTest");
         p.setDefinition(new CpsFlowDefinition(
-            "node { sauce('" + credentialsId + "') { sauceconnect(useGeneratedTunnelIdentifier: true, verboseLogging: true, options: '-i tunnel-ident') { \n" +
+            "node { sauce('" + credentialsId + "') { sauceconnect(useGeneratedTunnelName: true, verboseLogging: true, options: '-i tunnel-name') { \n" +
                 "echo 'USERNAME=' + env.SAUCE_USERNAME\n" +
                 "echo 'ACCESS_KEY=' + env.SAUCE_ACCESS_KEY\n" +
                 "}}}",
@@ -123,7 +123,7 @@ public class SauceStepTest {
             Mockito.eq("fakekey"),
             Mockito.anyInt(),
             isNull(),
-            Mockito.matches("-i gavin -vv -i tunnel-ident --tunnel-name [a-zA-Z0-9_-]+ -x https://saucelabs.com/rest/v1"),
+            Mockito.matches("-i gavin -vv -i tunnel-name --tunnel-name [a-zA-Z0-9_-]+ -x https://saucelabs.com/rest/v1"),
             Mockito.any(PrintStream.class),
             Mockito.eq(true),
             isNull()
@@ -134,7 +134,7 @@ public class SauceStepTest {
     public void sauceConnectWithoutSauceTest() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "SauceStepTest-sauceConnectWithoutSauceTest");
         p.setDefinition(new CpsFlowDefinition(
-            "node { sauceconnect(useGeneratedTunnelIdentifier: true, verboseLogging: true) { \n" +
+            "node { sauceconnect(useGeneratedTunnelName: true, verboseLogging: true) { \n" +
                 "echo 'USERNAME=' + env.SAUCE_USERNAME\n" +
                 "echo 'ACCESS_KEY=' + env.SAUCE_ACCESS_KEY\n" +
                 "}}",

--- a/src/test/java/com/saucelabs/jenkins/pipeline/SauceStepTest.java
+++ b/src/test/java/com/saucelabs/jenkins/pipeline/SauceStepTest.java
@@ -123,7 +123,7 @@ public class SauceStepTest {
             Mockito.eq("fakekey"),
             Mockito.anyInt(),
             isNull(),
-            Mockito.matches("-i gavin -vv -i tunnel-ident --tunnel-identifier [a-zA-Z0-9_-]+ -x https://saucelabs.com/rest/v1"),
+            Mockito.matches("-i gavin -vv -i tunnel-ident --tunnel-name [a-zA-Z0-9_-]+ -x https://saucelabs.com/rest/v1"),
             Mockito.any(PrintStream.class),
             Mockito.eq(true),
             isNull()

--- a/src/test/java/hudson/plugins/sauce_ondemand/ParameterizedSauceBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/ParameterizedSauceBuildWrapperTest.java
@@ -48,7 +48,7 @@ public class ParameterizedSauceBuildWrapperTest {
     public ParameterizedSauceBuildWrapperTest(
             boolean enableSauceConnect,
             boolean launchSauceConnectOnSlave,
-            boolean useGeneratedTunnelIdentifier,
+            boolean useGeneratedTunnelName,
             boolean verboseLogging,
             boolean useLatestVersion,
             boolean forceCleanup,
@@ -59,7 +59,7 @@ public class ParameterizedSauceBuildWrapperTest {
         sauceBuildWrapper = new TestSauceOnDemandBuildWrapper(null);
         sauceBuildWrapper.setEnableSauceConnect(enableSauceConnect);
         sauceBuildWrapper.setLaunchSauceConnectOnSlave(launchSauceConnectOnSlave);
-        sauceBuildWrapper.setUseGeneratedTunnelIdentifier(useGeneratedTunnelIdentifier);
+        sauceBuildWrapper.setUseGeneratedTunnelName(useGeneratedTunnelName);
         sauceBuildWrapper.setVerboseLogging(verboseLogging);
         sauceBuildWrapper.setUseLatestVersion(useLatestVersion);
         sauceBuildWrapper.setForceCleanup(forceCleanup);
@@ -72,7 +72,7 @@ public class ParameterizedSauceBuildWrapperTest {
         ArrayList<Object[]> list = new ArrayList<Object[]>();
         for(boolean enableSauceConnect : new boolean[] {true, false }) {
             for(boolean launchSauceConnectOnSlave : new boolean[] { true, false }) {
-                for (boolean useGeneratedTunnelIdentifier : new boolean[]{true, false}) {
+                for (boolean useGeneratedTunnelName : new boolean[]{true, false}) {
                     for (boolean verboseLogging : new boolean[]{true, false}) {
                         for (boolean useLatestVersion : new boolean[]{true, false}) {
                             for (boolean forceCleanup : new boolean[]{false}) { // set this to {true, false} for proper testing.  But it will increase test times by about 20m
@@ -81,7 +81,7 @@ public class ParameterizedSauceBuildWrapperTest {
                                         list.add(new Object[]{
                                                 enableSauceConnect,
                                                 launchSauceConnectOnSlave,
-                                                useGeneratedTunnelIdentifier,
+                                                useGeneratedTunnelName,
                                                 verboseLogging,
                                                 useLatestVersion,
                                                 forceCleanup,
@@ -206,11 +206,11 @@ public class ParameterizedSauceBuildWrapperTest {
         } else {
             assertThat("SAUCE_NATIVE_APP is set when native package is set", envVars.get("SAUCE_NATIVE_APP"), not(isEmptyOrNullString()));
         }
-        if (sauceBuildWrapper.isEnableSauceConnect() && sauceBuildWrapper.isUseGeneratedTunnelIdentifier()) {
-            assertThat("TUNNEL_IDENTIFIER is set when we are managing it", envVars.get("TUNNEL_IDENTIFIER"), not(isEmptyOrNullString()));
+        if (sauceBuildWrapper.isEnableSauceConnect() && sauceBuildWrapper.isUseGeneratedTunnelName()) {
+            assertThat("TUNNEL_NAME is set when we are managing it", envVars.get("TUNNEL_NAME"), not(isEmptyOrNullString()));
 
         } else {
-            assertNull("TUNNEL_IDENTIFIER is not set when we are not managing it", envVars.get("SAUCE_NATIVE_APP"));
+            assertNull("TUNNEL_NAME is not set when we are not managing it", envVars.get("SAUCE_NATIVE_APP"));
 
         }
         if (sauceBuildWrapper.isUseChromeForAndroid()) {

--- a/src/test/java/hudson/plugins/sauce_ondemand/SauceBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/SauceBuildWrapperTest.java
@@ -228,8 +228,8 @@ public class SauceBuildWrapperTest {
         SauceConnectFourManager sauceConnectFourManager = new SauceConnectFourManager() {
             @Override
             public Process openConnection(String username, String apiKey, int port, File sauceConnectJar, String options,  PrintStream printStream, Boolean verboseLogging, String sauceConnectPath) throws SauceConnectException {
-                // Match that it starts with tunnel-identifier, because timestamp
-                assertThat("Variables are resolved correctly", options, CoreMatchers.containsString("--global --build -i 1 --tunnel-identifier runFreestyleBuild-resolvedOptionsOrder-"));
+                // Match that it starts with tunnel-name, because timestamp
+                assertThat("Variables are resolved correctly", options, CoreMatchers.containsString("--global --build -i 1 --tunnel-name runFreestyleBuild-resolvedOptionsOrder-"));
                 return null;
             }
         };

--- a/src/test/java/hudson/plugins/sauce_ondemand/SauceBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/SauceBuildWrapperTest.java
@@ -237,7 +237,7 @@ public class SauceBuildWrapperTest {
         SauceOnDemandBuildWrapper sauceBuildWrapper = new TestSauceOnDemandBuildWrapper(credentialsId);
         PluginImpl.get().setSauceConnectOptions("--global");
         sauceBuildWrapper.setOptions("--build -i 1");
-        sauceBuildWrapper.setUseGeneratedTunnelIdentifier(true);
+        sauceBuildWrapper.setUseGeneratedTunnelName(true);
 
         Build build = runFreestyleBuild(sauceBuildWrapper, null, null, "resolvedOptionsOrder");
         jenkinsRule.assertBuildStatusSuccess(build);
@@ -307,7 +307,7 @@ public class SauceBuildWrapperTest {
 
         SauceOnDemandBuildWrapper sauceBuildWrapper = new TestSauceOnDemandBuildWrapper(credentialsId);
         sauceBuildWrapper.setEnableSauceConnect(true);
-        sauceBuildWrapper.setUseGeneratedTunnelIdentifier(true);
+        sauceBuildWrapper.setUseGeneratedTunnelName(true);
 
         final JSONObject holder = new JSONObject();
         SauceConnectFourManager sauceConnectFourManager = new SauceConnectFourManager() {
@@ -352,7 +352,7 @@ public class SauceBuildWrapperTest {
 
         SauceOnDemandBuildWrapper sauceBuildWrapper = new TestSauceOnDemandBuildWrapper(credentialsId);
         sauceBuildWrapper.setEnableSauceConnect(true);
-        sauceBuildWrapper.setUseGeneratedTunnelIdentifier(true);
+        sauceBuildWrapper.setUseGeneratedTunnelName(true);
         sauceBuildWrapper.setSeleniumPort("$TEST_PORT_VARIABLE_4321");
 
         final JSONObject holder = new JSONObject();

--- a/src/test/java/hudson/plugins/sauce_ondemand/SauceEnvironmentUtilTest.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/SauceEnvironmentUtilTest.java
@@ -10,30 +10,30 @@ import static org.hamcrest.Matchers.lessThan;
 public class SauceEnvironmentUtilTest {
 
     @Test
-    public void generateTunnelIdentifier_should_use_the_project_name_in_the_tunnel_id(){
+    public void generateTunnelName_should_use_the_project_name_in_the_tunnel_id(){
         String expectedProjectName = "My_Project_Name";
 
-        assertThat(SauceEnvironmentUtil.generateTunnelIdentifier(expectedProjectName), containsString(expectedProjectName));
+        assertThat(SauceEnvironmentUtil.generateTunnelName(expectedProjectName), containsString(expectedProjectName));
     }
 
     @Test
-    public void generateTunnelIdentifier_should_sanitize_the_project_name(){
+    public void generateTunnelName_should_sanitize_the_project_name(){
         String expectedProjectName = "My Project!@#$%&*()Name-012345689";
 
-        assertThat(SauceEnvironmentUtil.generateTunnelIdentifier(expectedProjectName), containsString("My_Project_Name-012345689"));
+        assertThat(SauceEnvironmentUtil.generateTunnelName(expectedProjectName), containsString("My_Project_Name-012345689"));
     }
 
     @Test
-    public void generateTunnelIdentifier_should_include_an_epoch_timestamp(){
+    public void generateTunnelName_should_include_an_epoch_timestamp(){
         String expectedProjectName = "My Project";
 
-        String tunnelIdentifier = SauceEnvironmentUtil.generateTunnelIdentifier(expectedProjectName);
+        String tunnelName = SauceEnvironmentUtil.generateTunnelName(expectedProjectName);
 
-        String epochTimeMSStr = tunnelIdentifier.split("-")[1];
+        String epochTimeMSStr = tunnelName.split("-")[1];
         long epochTimeMS = Long.parseLong(epochTimeMSStr);
         long now = System.currentTimeMillis();
-        int deltaBetweenNowAndTunnelIdentifier = (int) (now - epochTimeMS);
+        int deltaBetweenNowAndTunnelName = (int) (now - epochTimeMS);
 
-        assertThat(deltaBetweenNowAndTunnelIdentifier, is(lessThan(12)));
+        assertThat(deltaBetweenNowAndTunnelName, is(lessThan(12)));
     }
 }


### PR DESCRIPTION
The SC client 4.7.x or higher has deprecated the `--tunnel-identifier` option. Use `--tunnel-name` instead.