### PR TITLE
Restore the `useGeneratedTunnelIdentifier` config

### DIFF
--- a/src/main/java/com/saucelabs/jenkins/pipeline/SauceConnectStep.java
+++ b/src/main/java/com/saucelabs/jenkins/pipeline/SauceConnectStep.java
@@ -43,7 +43,7 @@ import static com.saucelabs.jenkins.pipeline.SauceConnectStep.SauceConnectStepEx
 public class SauceConnectStep extends Step {
     private Boolean verboseLogging = false;
     private Boolean useLatestSauceConnect = false;
-    private Boolean useGeneratedTunnelName = false;
+    private Boolean useGeneratedTunnelIdentifier = false;
     private String options;
     private String sauceConnectPath;
 
@@ -51,10 +51,10 @@ public class SauceConnectStep extends Step {
     public SauceConnectStep() {
     }
 
-    public SauceConnectStep(String options, Boolean verboseLogging, Boolean useLatestSauceConnect, Boolean useGeneratedTunnelName, String sauceConnectPath) {
+    public SauceConnectStep(String options, Boolean verboseLogging, Boolean useLatestSauceConnect, Boolean useGeneratedTunnelIdentifier, String sauceConnectPath) {
         this.verboseLogging = verboseLogging;
         this.useLatestSauceConnect = useLatestSauceConnect;
-        this.useGeneratedTunnelName = useGeneratedTunnelName;
+        this.useGeneratedTunnelIdentifier = useGeneratedTunnelIdentifier;
         this.sauceConnectPath = Util.fixEmptyAndTrim(sauceConnectPath);
         this.options = StringUtils.trimToEmpty(options);
     }
@@ -64,7 +64,7 @@ public class SauceConnectStep extends Step {
         return new SauceConnectStepExecution(context,
             PluginImpl.get().getSauceConnectOptions(),
             options,
-            useGeneratedTunnelName,
+            useGeneratedTunnelIdentifier,
             verboseLogging,
             sauceConnectPath,
             useLatestSauceConnect
@@ -90,13 +90,13 @@ public class SauceConnectStep extends Step {
         this.sauceConnectPath = sauceConnectPath;
     }
 
-    public Boolean getUseGeneratedTunnelName() {
-        return useGeneratedTunnelName;
+    public Boolean getUseGeneratedTunnelIdentifier() {
+        return useGeneratedTunnelIdentifier;
     }
 
     @DataBoundSetter
-    public void setUseGeneratedTunnelName(Boolean useGeneratedTunnelName) {
-        this.useGeneratedTunnelName = useGeneratedTunnelName;
+    public void setUseGeneratedTunnelIdentifier(Boolean useGeneratedTunnelIdentifier) {
+        this.useGeneratedTunnelIdentifier = useGeneratedTunnelIdentifier;
     }
 
     public Boolean getUseLatestSauceConnect() {
@@ -211,7 +211,7 @@ public class SauceConnectStep extends Step {
     public static class SauceConnectStepExecution extends StepExecution {
         private final String globalOptions;
         private final String options;
-        private final boolean useGeneratedTunnelName;
+        private final boolean useGeneratedTunnelIdentifier;
         private final boolean verboseLogging;
         private final String sauceConnectPath;
         private final boolean useLatestSauceConnect;
@@ -224,7 +224,7 @@ public class SauceConnectStep extends Step {
             @Nonnull StepContext context,
             String globalOptions,
             String options,
-            boolean useGeneratedTunnelName,
+            boolean useGeneratedTunnelIdentifier,
             boolean verboseLogging,
             String sauceConnectPath,
             boolean useLatestSauceConnect
@@ -232,7 +232,7 @@ public class SauceConnectStep extends Step {
             super(context);
             this.globalOptions = globalOptions;
             this.options = options;
-            this.useGeneratedTunnelName = useGeneratedTunnelName;
+            this.useGeneratedTunnelIdentifier = useGeneratedTunnelIdentifier;
             this.verboseLogging = verboseLogging;
             this.sauceConnectPath = sauceConnectPath;
             this.useLatestSauceConnect = useLatestSauceConnect;
@@ -266,7 +266,7 @@ public class SauceConnectStep extends Step {
             overrides.put(SauceOnDemandBuildWrapper.SELENIUM_PORT, String.valueOf(port));
             overrides.put(SauceOnDemandBuildWrapper.SELENIUM_HOST, "localhost");
 
-            if (useGeneratedTunnelName) {
+            if (useGeneratedTunnelIdentifier) {
                 final String tunnelName = SauceEnvironmentUtil.generateTunnelName(job.getName());
                 overrides.put(SauceOnDemandBuildWrapper.TUNNEL_NAME, tunnelName);
                 options = options + " --tunnel-name " + tunnelName;

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
@@ -172,7 +172,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
      */
     private static final String SAUCE_USE_CHROME = "SAUCE_USE_CHROME";
 
-    private boolean useGeneratedTunnelName;
+    private boolean useGeneratedTunnelIdentifier;
 
     private static final long serialVersionUID = 1L;
     /**
@@ -271,23 +271,23 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
 
     /**
      * Constructs a new instance using data entered on the job configuration screen.
-     * @param enableSauceConnect        indicates whether Sauce Connect should be started as part of the build.
-     * @param condition                 allows users to define rules which enable Sauce Connect
-     * @param seleniumInformation       the browser information that is to be used for the build.
-     * @param seleniumHost              host location of the selenium server.
-     * @param seleniumPort              port location of the selenium server.
-     * @param options                   the Sauce Connect command line options to be used
-     * @param sauceConnectPath          Path to sauce connect
-     * @param launchSauceConnectOnSlave indicates whether Sauce Connect should be launched on the slave or master node
-     * @param verboseLogging            indicates whether the Sauce Connect output should be written to the Jenkins job output
-     * @param useLatestVersion          indicates whether the latest version of the selected browser(s) should be used
-     * @param useLatestSauceConnect     indicates whether the latest version of Sauce Connect should always be used
-     * @param forceCleanup              indicates whether to force cleanup for jobs/tunnels instead of waiting for timeout
-     * @param webDriverBrowsers         which browser(s) should be used for web driver
-     * @param appiumBrowsers            which browser(s) should be used for appium
-     * @param nativeAppPackage          the path to the native app package to be tested
-     * @param useGeneratedTunnelName    indicated whether tunnel names and ports should be managed by the plugin
-     * @param credentialId              Which credential a build should use
+     * @param enableSauceConnect              indicates whether Sauce Connect should be started as part of the build.
+     * @param condition                       allows users to define rules which enable Sauce Connect
+     * @param seleniumInformation             the browser information that is to be used for the build.
+     * @param seleniumHost                    host location of the selenium server.
+     * @param seleniumPort                    port location of the selenium server.
+     * @param options                         the Sauce Connect command line options to be used
+     * @param sauceConnectPath                Path to sauce connect
+     * @param launchSauceConnectOnSlave       indicates whether Sauce Connect should be launched on the slave or master node
+     * @param verboseLogging                  indicates whether the Sauce Connect output should be written to the Jenkins job output
+     * @param useLatestVersion                indicates whether the latest version of the selected browser(s) should be used
+     * @param useLatestSauceConnect           indicates whether the latest version of Sauce Connect should always be used
+     * @param forceCleanup                    indicates whether to force cleanup for jobs/tunnels instead of waiting for timeout
+     * @param webDriverBrowsers               which browser(s) should be used for web driver
+     * @param appiumBrowsers                  which browser(s) should be used for appium
+     * @param nativeAppPackage                the path to the native app package to be tested
+     * @param useGeneratedTunnelIdentifier    indicated whether tunnel names and ports should be managed by the plugin
+     * @param credentialId                    Which credential a build should use
      */
     @DataBoundConstructor
     public SauceOnDemandBuildWrapper(
@@ -308,7 +308,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
         List<String> appiumBrowsers,
         String nativeAppPackage,
 //            boolean useChromeForAndroid,
-        boolean useGeneratedTunnelName
+        boolean useGeneratedTunnelIdentifier
     ) {
         this.seleniumInformation = seleniumInformation;
         this.enableSauceConnect = enableSauceConnect;
@@ -330,7 +330,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
         this.sauceConnectPath = sauceConnectPath;
         this.nativeAppPackage = nativeAppPackage;
 //        this.useChromeForAndroid = useChromeForAndroid;
-        this.useGeneratedTunnelName = useGeneratedTunnelName;
+        this.useGeneratedTunnelIdentifier = useGeneratedTunnelIdentifier;
         this.credentialId = credentialId;
     }
 
@@ -365,7 +365,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
             String retryWaitTime = p != null ? p.getSauceConnectRetryWaitTime() : null;
             String resolvedOptions = getCommandLineOptions(build, listener);
 
-            if (isUseGeneratedTunnelName()) {
+            if (isUseGeneratedTunnelIdentifier()) {
                 build.getBuildVariables().put(TUNNEL_NAME, tunnelName);
                 resolvedOptions = resolvedOptions + " --tunnel-name " + tunnelName;
             }
@@ -435,7 +435,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
                     props.put("plugin", "jenkins");
                     props.put("enableSauceConnect", enableSauceConnect);
                     props.put("verboseLogging", verboseLogging);
-                    props.put("useGeneratedTunnelName", useGeneratedTunnelName);
+                    props.put("useGeneratedTunnelIdentifier", useGeneratedTunnelIdentifier);
                     props.put("launchSauceConnectOnSlave", launchSauceConnectOnSlave);
                     props.put("webDriverBrowsers", webDriverBrowsers);
                     props.put("appiumBrowsers", appiumBrowsers);
@@ -521,7 +521,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
                     SauceEnvironmentUtil.outputEnvironmentVariable(env, SAUCE_NATIVE_APP, getNativeAppPackage(), true, verboseLogging, listener.getLogger());
                 }
 
-                if (isEnableSauceConnect() && isUseGeneratedTunnelName()) {
+                if (isEnableSauceConnect() && isUseGeneratedTunnelIdentifier()) {
                     SauceEnvironmentUtil.outputEnvironmentVariable(env, TUNNEL_NAME, tunnelName, true, verboseLogging, listener.getLogger());
                 }
 
@@ -580,7 +580,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
                         listener.getLogger().println("Shutting down Sauce Connect");
                         String resolvedOptions = getCommandLineOptions(build, listener);
 
-                        if (isUseGeneratedTunnelName()) {
+                        if (isUseGeneratedTunnelIdentifier()) {
                             build.getBuildVariables().put(TUNNEL_NAME, tunnelName);
                             resolvedOptions = "--tunnel-name " + tunnelName + " " + resolvedOptions;
                         }
@@ -610,7 +610,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
                     // this is needed as aborting during tunnel creation will prevent it from closing properly above
                     SauceCredentials credentials = SauceCredentials.getSauceCredentials(build, SauceOnDemandBuildWrapper.this); // get credentials
                     JenkinsSauceREST sauceREST = credentials.getSauceREST(); // use credentials to get sauceRest
-                    if (isEnableSauceConnect() && isUseGeneratedTunnelName()) {
+                    if (isEnableSauceConnect() && isUseGeneratedTunnelIdentifier()) {
                         try {
                             String listResponse = sauceREST.getTunnels();
                             JSONArray tunnels = new JSONArray(listResponse);
@@ -774,7 +774,7 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
             }
         } else {
             if (isEnableSauceConnect()) {
-                if (isUseGeneratedTunnelName()) {
+                if (isUseGeneratedTunnelIdentifier()) {
                     try {
                         if (launchSauceConnectOnSlave) {
                             return Computer.currentComputer().getChannel().call(new GetAvailablePort());
@@ -867,12 +867,12 @@ public class SauceOnDemandBuildWrapper extends BuildWrapper implements Serializa
         this.useLatestSauceConnect = useLatestSauceConnect;
     }
 
-    public boolean isUseGeneratedTunnelName() {
-        return useGeneratedTunnelName;
+    public boolean isUseGeneratedTunnelIdentifier() {
+        return useGeneratedTunnelIdentifier;
     }
 
-    public void setUseGeneratedTunnelName(boolean useGeneratedTunnelName) {
-        this.useGeneratedTunnelName = useGeneratedTunnelName;
+    public void setUseGeneratedTunnelIdentifier(boolean useGeneratedTunnelIdentifier) {
+        this.useGeneratedTunnelIdentifier = useGeneratedTunnelIdentifier;
     }
 
     public boolean isVerboseLogging() {

--- a/src/main/resources/com/saucelabs/jenkins/pipeline/SauceConnectStep/config.jelly
+++ b/src/main/resources/com/saucelabs/jenkins/pipeline/SauceConnectStep/config.jelly
@@ -7,7 +7,7 @@
     <f:entry field="options" title="${%Sauce Connect Options}">
         <f:textbox/>
     </f:entry>
-    <f:entry field="useGeneratedTunnelName">
+    <f:entry field="useGeneratedTunnelIdentifier">
         <f:checkbox title="${%Create a new unique Sauce Connect tunnel per build}"/>
     </f:entry>
     <f:entry field="useLatestSauceConnect"

--- a/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper/config.jelly
+++ b/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper/config.jelly
@@ -89,7 +89,7 @@
                 <f:entry title="${%Sauce Connect Options}" field="options">
                     <f:textbox/>
                 </f:entry>
-                <f:entry field="useGeneratedTunnelName">
+                <f:entry field="useGeneratedTunnelIdentifier">
                     <f:checkbox title="${%Create a new unique Sauce Connect tunnel per build}"/>
                 </f:entry>
 

--- a/src/test/java/com/saucelabs/jenkins/pipeline/SauceStepTest.java
+++ b/src/test/java/com/saucelabs/jenkins/pipeline/SauceStepTest.java
@@ -108,7 +108,7 @@ public class SauceStepTest {
 
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "SauceStepTest-sauceConnectWithGlobalOptionsTest");
         p.setDefinition(new CpsFlowDefinition(
-            "node { sauce('" + credentialsId + "') { sauceconnect(useGeneratedTunnelName: true, verboseLogging: true, options: '-i tunnel-name') { \n" +
+            "node { sauce('" + credentialsId + "') { sauceconnect(useGeneratedTunnelIdentifier: true, verboseLogging: true, options: '-i tunnel-name') { \n" +
                 "echo 'USERNAME=' + env.SAUCE_USERNAME\n" +
                 "echo 'ACCESS_KEY=' + env.SAUCE_ACCESS_KEY\n" +
                 "}}}",
@@ -134,7 +134,7 @@ public class SauceStepTest {
     public void sauceConnectWithoutSauceTest() throws Exception {
         WorkflowJob p = r.jenkins.createProject(WorkflowJob.class, "SauceStepTest-sauceConnectWithoutSauceTest");
         p.setDefinition(new CpsFlowDefinition(
-            "node { sauceconnect(useGeneratedTunnelName: true, verboseLogging: true) { \n" +
+            "node { sauceconnect(useGeneratedTunnelIdentifier: true, verboseLogging: true) { \n" +
                 "echo 'USERNAME=' + env.SAUCE_USERNAME\n" +
                 "echo 'ACCESS_KEY=' + env.SAUCE_ACCESS_KEY\n" +
                 "}}",

--- a/src/test/java/hudson/plugins/sauce_ondemand/ParameterizedSauceBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/ParameterizedSauceBuildWrapperTest.java
@@ -48,7 +48,7 @@ public class ParameterizedSauceBuildWrapperTest {
     public ParameterizedSauceBuildWrapperTest(
             boolean enableSauceConnect,
             boolean launchSauceConnectOnSlave,
-            boolean useGeneratedTunnelName,
+            boolean useGeneratedTunnelIdentifier,
             boolean verboseLogging,
             boolean useLatestVersion,
             boolean forceCleanup,
@@ -59,7 +59,7 @@ public class ParameterizedSauceBuildWrapperTest {
         sauceBuildWrapper = new TestSauceOnDemandBuildWrapper(null);
         sauceBuildWrapper.setEnableSauceConnect(enableSauceConnect);
         sauceBuildWrapper.setLaunchSauceConnectOnSlave(launchSauceConnectOnSlave);
-        sauceBuildWrapper.setUseGeneratedTunnelName(useGeneratedTunnelName);
+        sauceBuildWrapper.setUseGeneratedTunnelIdentifier(useGeneratedTunnelIdentifier);
         sauceBuildWrapper.setVerboseLogging(verboseLogging);
         sauceBuildWrapper.setUseLatestVersion(useLatestVersion);
         sauceBuildWrapper.setForceCleanup(forceCleanup);
@@ -72,7 +72,7 @@ public class ParameterizedSauceBuildWrapperTest {
         ArrayList<Object[]> list = new ArrayList<Object[]>();
         for(boolean enableSauceConnect : new boolean[] {true, false }) {
             for(boolean launchSauceConnectOnSlave : new boolean[] { true, false }) {
-                for (boolean useGeneratedTunnelName : new boolean[]{true, false}) {
+                for (boolean useGeneratedTunnelIdentifier : new boolean[]{true, false}) {
                     for (boolean verboseLogging : new boolean[]{true, false}) {
                         for (boolean useLatestVersion : new boolean[]{true, false}) {
                             for (boolean forceCleanup : new boolean[]{false}) { // set this to {true, false} for proper testing.  But it will increase test times by about 20m
@@ -81,7 +81,7 @@ public class ParameterizedSauceBuildWrapperTest {
                                         list.add(new Object[]{
                                                 enableSauceConnect,
                                                 launchSauceConnectOnSlave,
-                                                useGeneratedTunnelName,
+                                                useGeneratedTunnelIdentifier,
                                                 verboseLogging,
                                                 useLatestVersion,
                                                 forceCleanup,
@@ -206,7 +206,7 @@ public class ParameterizedSauceBuildWrapperTest {
         } else {
             assertThat("SAUCE_NATIVE_APP is set when native package is set", envVars.get("SAUCE_NATIVE_APP"), not(isEmptyOrNullString()));
         }
-        if (sauceBuildWrapper.isEnableSauceConnect() && sauceBuildWrapper.isUseGeneratedTunnelName()) {
+        if (sauceBuildWrapper.isEnableSauceConnect() && sauceBuildWrapper.isUseGeneratedTunnelIdentifier()) {
             assertThat("TUNNEL_NAME is set when we are managing it", envVars.get("TUNNEL_NAME"), not(isEmptyOrNullString()));
 
         } else {

--- a/src/test/java/hudson/plugins/sauce_ondemand/SauceBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/SauceBuildWrapperTest.java
@@ -237,7 +237,7 @@ public class SauceBuildWrapperTest {
         SauceOnDemandBuildWrapper sauceBuildWrapper = new TestSauceOnDemandBuildWrapper(credentialsId);
         PluginImpl.get().setSauceConnectOptions("--global");
         sauceBuildWrapper.setOptions("--build -i 1");
-        sauceBuildWrapper.setUseGeneratedTunnelName(true);
+        sauceBuildWrapper.setUseGeneratedTunnelIdentifier(true);
 
         Build build = runFreestyleBuild(sauceBuildWrapper, null, null, "resolvedOptionsOrder");
         jenkinsRule.assertBuildStatusSuccess(build);
@@ -307,7 +307,7 @@ public class SauceBuildWrapperTest {
 
         SauceOnDemandBuildWrapper sauceBuildWrapper = new TestSauceOnDemandBuildWrapper(credentialsId);
         sauceBuildWrapper.setEnableSauceConnect(true);
-        sauceBuildWrapper.setUseGeneratedTunnelName(true);
+        sauceBuildWrapper.setUseGeneratedTunnelIdentifier(true);
 
         final JSONObject holder = new JSONObject();
         SauceConnectFourManager sauceConnectFourManager = new SauceConnectFourManager() {
@@ -352,7 +352,7 @@ public class SauceBuildWrapperTest {
 
         SauceOnDemandBuildWrapper sauceBuildWrapper = new TestSauceOnDemandBuildWrapper(credentialsId);
         sauceBuildWrapper.setEnableSauceConnect(true);
-        sauceBuildWrapper.setUseGeneratedTunnelName(true);
+        sauceBuildWrapper.setUseGeneratedTunnelIdentifier(true);
         sauceBuildWrapper.setSeleniumPort("$TEST_PORT_VARIABLE_4321");
 
         final JSONObject holder = new JSONObject();


### PR DESCRIPTION
The config setting was renamed to match the SC 4.7+ command line option,
however this caused the old config setting to be lost, and caused
unnamed tunnels to be used instead. This reverts the change in the
Jenkins plugin config, but continues to use the new CLI option name.