### PR TITLE
Fix EU datacentre name

### DIFF
--- a/src/main/java/hudson/plugins/sauce_ondemand/credentials/SauceCredentials.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/credentials/SauceCredentials.java
@@ -147,7 +147,7 @@ public class SauceCredentials extends BaseStandardCredentials implements Standar
 
         switch (this.restEndpoint) {
             case "https://eu-central-1.saucelabs.com/":
-                return "US";
+                return "EU";
             case "https://us-east-1.saucelabs.com/":
                 return "US_EAST";
             default:


### PR DESCRIPTION
Fix the string passed to the SauceREST API when using the EU datacentre.