### PR TITLE
Handle new SauceREST API, use new exception for deleteTunnel()

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
         <jenkins.version>2.249.1</jenkins.version>
-        <ci-sauce.version>1.164</ci-sauce.version>
-        <saucerest.version>1.2.0</saucerest.version>
+        <ci-sauce.version>1.167</ci-sauce.version>
+        <saucerest.version>2.0.2</saucerest.version>
     </properties>
 
 
@@ -179,6 +179,36 @@
             </exclusions>
         </dependency>
         <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.9.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.9.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.9.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-params</artifactId>
+            <version>5.9.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-engine</artifactId>
+            <version>1.9.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.platform</groupId>
+            <artifactId>junit-platform-commons</artifactId>
+            <version>1.9.2</version>
+        </dependency>
+        <dependency>
             <groupId>org.jenkins-ci.main</groupId>
             <artifactId>maven-plugin</artifactId>
             <version>3.8</version>
@@ -243,6 +273,12 @@
             <groupId>org.json</groupId>
             <artifactId>json</artifactId>
             <version>20220924</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>1.7.0</version>
         </dependency>
 
         <dependency>

--- a/src/main/java/hudson/plugins/sauce_ondemand/AppiumAxis.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/AppiumAxis.java
@@ -6,6 +6,7 @@ import hudson.matrix.AxisDescriptor;
 import org.json.JSONException;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
@@ -60,6 +61,8 @@ public class AppiumAxis extends BrowserAxis {
                 return BROWSER_FACTORY.getAppiumBrowsers();
             } catch (JSONException e) {
                 logger.log(Level.WARNING, "Error parsing JSON response", e);
+            } catch (IOException e) {
+                logger.log(Level.WARNING, "Error retrieving response", e);
             }
             return Collections.emptyList();
         }

--- a/src/main/java/hudson/plugins/sauce_ondemand/BrowserAxis.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/BrowserAxis.java
@@ -42,7 +42,7 @@ import java.util.Map;
 public abstract class BrowserAxis extends Axis {
 
     /** Handles the retrieval of browsers from Sauce Labs. */
-    protected static final BrowserFactory BROWSER_FACTORY = BrowserFactory.getInstance(new JenkinsSauceREST(null, null, null));
+    protected static final BrowserFactory BROWSER_FACTORY = BrowserFactory.getInstance(new JenkinsSauceREST(null, null, "US_WEST"));
     private transient MatrixProject project;
 
     public BrowserAxis(List<String> values) {

--- a/src/main/java/hudson/plugins/sauce_ondemand/PluginImpl.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/PluginImpl.java
@@ -56,21 +56,24 @@ import java.util.logging.Logger;
 public class PluginImpl extends Plugin implements Describable<PluginImpl> {
 
     private static final Logger logger = Logger.getLogger(PluginImpl.class.getName());
+
     /**
      * Handles the retrieval of browsers from Sauce Labs.
      */
-    static transient final BrowserFactory BROWSER_FACTORY = BrowserFactory.getInstance(new JenkinsSauceREST(null, null, null));
+    static transient final BrowserFactory BROWSER_FACTORY = BrowserFactory.getInstance(new JenkinsSauceREST(null, null, "US_WEST"));
 
     /**
      * User name to access Sauce OnDemand.
      */
     @Deprecated
     private transient String username;
+
     /**
      * Password for Sauce OnDemand.
      */
     @Deprecated
     private transient Secret apiKey;
+
     /**
      * Data center endpoint for Sauce OnDemand.
      */

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper.java
@@ -26,7 +26,6 @@ package hudson.plugins.sauce_ondemand;
 import com.cloudbees.plugins.credentials.CredentialsProvider;
 import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
 import com.saucelabs.ci.Browser;
-import com.saucelabs.ci.BrowserFactory;
 import com.saucelabs.ci.sauceconnect.AbstractSauceTunnelManager;
 import com.saucelabs.jenkins.HudsonSauceConnectFourManager;
 import com.saucelabs.jenkins.HudsonSauceManagerFactory;

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceParameterDefinition.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceParameterDefinition.java
@@ -2,6 +2,7 @@ package hudson.plugins.sauce_ondemand;
 
 import com.saucelabs.ci.Browser;
 import com.saucelabs.ci.BrowserFactory;
+import hudson.plugins.sauce_ondemand.credentials.SauceCredentials;
 import hudson.Extension;
 import hudson.model.ParameterDefinition;
 import hudson.model.ParameterValue;
@@ -11,6 +12,7 @@ import org.json.JSONException;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.StaplerRequest;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
@@ -27,7 +29,7 @@ public class SauceParameterDefinition extends ParameterDefinition {
     private static final Logger logger = Logger.getLogger(SauceParameterDefinition.class.getName());
 
     /** Handles the retrieval of browsers from Sauce Labs. */
-    private static final BrowserFactory BROWSER_FACTORY = BrowserFactory.getInstance(new JenkinsSauceREST(null, null, null));
+    private static final BrowserFactory BROWSER_FACTORY = BrowserFactory.getInstance(new JenkinsSauceREST(null, null, "US_WEST"));
 
     @DataBoundConstructor
     public SauceParameterDefinition() {
@@ -50,6 +52,8 @@ public class SauceParameterDefinition extends ParameterDefinition {
     public List<Browser> getWebDriverBrowsers() {
         try {
             return BROWSER_FACTORY.getWebDriverBrowsers();
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "Error retrieving response", e);
         } catch (JSONException e) {
             logger.log(Level.SEVERE, "Error parsing JSON response", e);
         }

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceParameterDefinition.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceParameterDefinition.java
@@ -2,7 +2,6 @@ package hudson.plugins.sauce_ondemand;
 
 import com.saucelabs.ci.Browser;
 import com.saucelabs.ci.BrowserFactory;
-import hudson.plugins.sauce_ondemand.credentials.SauceCredentials;
 import hudson.Extension;
 import hudson.model.ParameterDefinition;
 import hudson.model.ParameterValue;

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceParameterValue.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceParameterValue.java
@@ -16,7 +16,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class SauceParameterValue extends ParameterValue {
 
     /** Handles the retrieval of browsers from Sauce Labs. */
-    private static final BrowserFactory BROWSER_FACTORY = BrowserFactory.getInstance(new JenkinsSauceREST(null, null, null));
+    private static final BrowserFactory BROWSER_FACTORY = BrowserFactory.getInstance(new JenkinsSauceREST(null, null, "US_WEST"));
 
     private final String selectedBrowsersString;
 

--- a/src/main/java/hudson/plugins/sauce_ondemand/WebDriverAxis.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/WebDriverAxis.java
@@ -1,8 +1,6 @@
 package hudson.plugins.sauce_ondemand;
 
 import com.saucelabs.ci.Browser;
-import com.saucelabs.ci.BrowserFactory;
-import hudson.plugins.sauce_ondemand.credentials.SauceCredentials;
 import hudson.Extension;
 import hudson.matrix.AxisDescriptor;
 import org.json.JSONException;

--- a/src/main/java/hudson/plugins/sauce_ondemand/WebDriverAxis.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/WebDriverAxis.java
@@ -1,11 +1,14 @@
 package hudson.plugins.sauce_ondemand;
 
 import com.saucelabs.ci.Browser;
+import com.saucelabs.ci.BrowserFactory;
+import hudson.plugins.sauce_ondemand.credentials.SauceCredentials;
 import hudson.Extension;
 import hudson.matrix.AxisDescriptor;
 import org.json.JSONException;
 import org.kohsuke.stapler.DataBoundConstructor;
 
+import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
@@ -58,6 +61,8 @@ public class WebDriverAxis extends BrowserAxis {
         public List<Browser> getBrowsers() {
             try {
                 return BROWSER_FACTORY.getWebDriverBrowsers();
+            } catch (IOException e) {
+                logger.log(Level.WARNING, "Error retrieving response", e);
             } catch (JSONException e) {
                 logger.log(Level.WARNING, "Error parsing JSON response", e);
             }

--- a/src/main/java/hudson/plugins/sauce_ondemand/credentials/SauceCredentials.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/credentials/SauceCredentials.java
@@ -141,17 +141,17 @@ public class SauceCredentials extends BaseStandardCredentials implements Standar
     @NonNull
     public String getRestEndpointName() {
         if (this.restEndpoint == null) {
-            return "US";
+            return "US_WEST";
         }
 
         switch (this.restEndpoint) {
             case "https://eu-central-1.saucelabs.com/":
-                return "EU";
+                return "EU_CENTRAL";
             case "https://us-east-1.saucelabs.com/":
                 return "US_EAST";
             default:
             case "https://saucelabs.com/":
-                return "US";
+                return "US_WEST";
         }
     }
 
@@ -187,6 +187,10 @@ public class SauceCredentials extends BaseStandardCredentials implements Standar
 
         @SuppressWarnings("unused") // used by stapler
         public FormValidation doCheckApiKey(@QueryParameter String value, @QueryParameter String username, @QueryParameter String dataCenter) {
+            if (dataCenter == null) {
+                dataCenter = "US_WEST";
+            }
+
             JenkinsSauceREST rest = new JenkinsSauceREST(username, value, dataCenter);
             // If unauthorized getUser returns an empty string.
             if (rest.getUser().equals("")) {

--- a/src/test/java/com/saucelabs/jenkins/pipeline/SauceStepTest.java
+++ b/src/test/java/com/saucelabs/jenkins/pipeline/SauceStepTest.java
@@ -122,7 +122,7 @@ public class SauceStepTest {
         Mockito.verify(sauceConnectFourManager).openConnection(
             Mockito.eq("fakeuser"),
             Mockito.eq("fakekey"),
-            Mockito.eq("US"),
+            Mockito.eq("US_WEST"),
             Mockito.anyInt(),
             isNull(),
             Mockito.matches("-i gavin -vv -i tunnel-name --tunnel-name [a-zA-Z0-9_-]+ -x https://saucelabs.com/rest/v1"),

--- a/src/test/java/hudson/plugins/sauce_ondemand/ParameterizedSauceBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/ParameterizedSauceBuildWrapperTest.java
@@ -4,6 +4,9 @@ import com.saucelabs.ci.sauceconnect.SauceConnectFourManager;
 import com.saucelabs.jenkins.HudsonSauceManagerFactory;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import hudson.Launcher;
+import hudson.PluginManager;
+import hudson.PluginWrapper;
+import hudson.Plugin;
 import hudson.model.*;
 import hudson.model.queue.QueueTaskFuture;
 import hudson.plugins.sauce_ondemand.credentials.SauceCredentials;
@@ -126,7 +129,10 @@ public class ParameterizedSauceBuildWrapperTest {
 
         sauceBuildWrapper.setCredentialId(credentialsId);
 
-        jenkinsRule.getPluginManager().getPlugin("sauce-ondemand").getPlugin().configure(null, pluginConfig);
+        PluginManager manager = jenkinsRule.getPluginManager();
+        PluginWrapper plugin = manager.getPlugin("sauce-ondemand");
+        Plugin p2 = plugin.getPlugin();
+        p2.configure(null, pluginConfig);
 
     }
 

--- a/src/test/java/hudson/plugins/sauce_ondemand/mocks/MockSauceREST.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/mocks/MockSauceREST.java
@@ -8,7 +8,7 @@ import java.net.URL;
 public class MockSauceREST extends JenkinsSauceREST {
 
     public MockSauceREST() {
-        super("fake", "", "US");
+        super("fake", "", "US_WEST");
     }
 
     @Override


### PR DESCRIPTION
* Catch exceptions thrown in `deleteTunnel()` .
* Update SauceREST to 2.0.2
  * Changes in this dependency threw new exceptions, so we need to handle these as well.