### PR TITLE
Bump ci-sauce to 1.168 and SauceREST to 2.0.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,8 +13,8 @@
         <gitHubRepo>jenkinsci/${project.artifactId}-plugin</gitHubRepo>
         <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
         <jenkins.version>2.249.1</jenkins.version>
-        <ci-sauce.version>1.167</ci-sauce.version>
-        <saucerest.version>2.0.2</saucerest.version>
+        <ci-sauce.version>1.168</ci-sauce.version>
+        <saucerest.version>2.0.3</saucerest.version>
     </properties>
 
 


### PR DESCRIPTION
This allows the test to pass even if the tunnel fails to shut down cleanly.