### PR TITLE
Don't fail a job if it fails to upload stats to Mixpanel

### DIFF
--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandTestPublisher.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandTestPublisher.java
@@ -109,7 +109,7 @@ public class SauceOnDemandTestPublisher extends Recorder implements SimpleBuildS
             delivery.addMessage(sentEvent);
             MixpanelAPI mixpanel = new MixpanelAPI();
             mixpanel.deliver(delivery);
-        } catch (JSONException e) {
+        } catch (JSONException | java.net.SocketTimeoutException e) {
             listener.getLogger().println("Could not send junit status: " + e.getMessage());
         }
 


### PR DESCRIPTION
Failing to upload stats shouldn't cause a job to fail.