### PR TITLE
Fix sauce labs connection when running on agents

### DIFF
--- a/src/main/java/hudson/plugins/sauce_ondemand/BrowserAxis.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/BrowserAxis.java
@@ -30,6 +30,8 @@ import hudson.matrix.Axis;
 import hudson.matrix.MatrixBuild;
 import hudson.matrix.MatrixProject;
 import hudson.plugins.sauce_ondemand.credentials.SauceCredentials;
+import jenkins.model.Jenkins;
+
 import java.util.List;
 import java.util.Map;
 
@@ -42,7 +44,7 @@ import java.util.Map;
 public abstract class BrowserAxis extends Axis {
 
     /** Handles the retrieval of browsers from Sauce Labs. */
-    protected static final BrowserFactory BROWSER_FACTORY = BrowserFactory.getInstance(new JenkinsSauceREST(null, null, DataCenter.US_WEST));
+    protected static final BrowserFactory BROWSER_FACTORY = BrowserFactory.getInstance(new JenkinsSauceREST(null, null, DataCenter.US_WEST, Jenkins.get().getProxy()));
     private transient MatrixProject project;
 
     public BrowserAxis(List<String> values) {

--- a/src/main/java/hudson/plugins/sauce_ondemand/JenkinsSauceREST.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/JenkinsSauceREST.java
@@ -29,8 +29,8 @@ public class JenkinsSauceREST extends SauceREST {
       "Jenkins/" + Jenkins.VERSION + " " + "JenkinsSauceOnDemand/" + BuildUtils.getCurrentVersion();
   private String server = getSauceRestUrlFromEnv();
 
-  public JenkinsSauceREST(String username, String accessKey, DataCenter dataCenter) {
-    super(username, accessKey, dataCenter, getJenkinsPluginHttpConfig(dataCenter));
+  public JenkinsSauceREST(String username, String accessKey, DataCenter dataCenter, ProxyConfiguration proxy) {
+    super(username, accessKey, dataCenter, getJenkinsPluginHttpConfig(dataCenter, proxy));
     if (server == null) {
       server = dataCenter.server();
     }
@@ -44,24 +44,23 @@ public class JenkinsSauceREST extends SauceREST {
     return srUrl;
   }
 
-  private static HttpClientConfig getJenkinsPluginHttpConfig(DataCenter dataCenter) {
+  private static HttpClientConfig getJenkinsPluginHttpConfig(DataCenter dataCenter, ProxyConfiguration proxyConfig) {
     String server = getSauceRestUrlFromEnv();
     if (server == null) {
       server = dataCenter.server();
     }
     Proxy proxy = null;
     Authenticator auth = Authenticator.NONE;
-    ProxyConfiguration pc = Jenkins.get().getProxy();
 
-    if (pc != null) {
+    if (proxyConfig != null) {
       String host = Objects.requireNonNull(buildURL(server)).getHost();
-      proxy = pc.createProxy(host);
+      proxy = proxyConfig.createProxy(host);
 
-      if (pc.getUserName() != null
-          && !pc.getUserName().isEmpty()
-          && pc.getSecretPassword() != null
-          && !pc.getSecretPassword().getPlainText().isEmpty()) {
-        auth = new ProxyAuthenticator(pc.getUserName(), pc.getSecretPassword().getPlainText());
+      if (proxyConfig.getUserName() != null
+          && !proxyConfig.getUserName().isEmpty()
+          && proxyConfig.getSecretPassword() != null
+          && !proxyConfig.getSecretPassword().getPlainText().isEmpty()) {
+        auth = new ProxyAuthenticator(proxyConfig.getUserName(), proxyConfig.getSecretPassword().getPlainText());
       }
     }
     UserAgentInterceptor ua = new UserAgentInterceptor(userAgent);

--- a/src/main/java/hudson/plugins/sauce_ondemand/PluginImpl.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/PluginImpl.java
@@ -54,7 +54,7 @@ public class PluginImpl extends Plugin implements Describable<PluginImpl> {
 
   /** Handles the retrieval of browsers from Sauce Labs. */
   static final BrowserFactory BROWSER_FACTORY =
-      BrowserFactory.getInstance(new JenkinsSauceREST(null, null, DataCenter.US_WEST));
+      BrowserFactory.getInstance(new JenkinsSauceREST(null, null, DataCenter.US_WEST, null));
   private static final Logger logger = Logger.getLogger(PluginImpl.class.getName());
   /** Username to access Sauce OnDemand. */
   @Deprecated private transient String username;

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildAction.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandBuildAction.java
@@ -34,6 +34,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import javax.servlet.ServletException;
+
+import jenkins.model.Jenkins;
 import jenkins.model.RunAction2;
 import jenkins.tasks.SimpleBuildStep;
 import jenkins.util.Timer;
@@ -440,7 +442,7 @@ public class SauceOnDemandBuildAction extends AbstractAction
 
     DataCenter dc = DataCenter.fromString(dataCenter);
 
-    return new JenkinsSauceREST(username, accessKey, dc);
+    return new JenkinsSauceREST(username, accessKey, dc, Jenkins.get().getProxy());
   }
 
   public SauceTestResultsById getById(String id) {

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandReportPublisher.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceOnDemandReportPublisher.java
@@ -58,6 +58,8 @@ import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import jenkins.model.Jenkins;
 import org.json.JSONException;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.DataBoundSetter;
@@ -399,7 +401,7 @@ public class SauceOnDemandReportPublisher extends TestDataPublisher {
   }
 
   protected JenkinsSauceREST getSauceREST(Run build) {
-    return SauceOnDemandBuildAction.getSauceBuildAction(build).getCredentials().getSauceREST();
+    return SauceOnDemandBuildAction.getSauceBuildAction(build).getCredentials().getSauceREST(Jenkins.get().getProxy());
   }
 
   /**

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceParameterDefinition.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceParameterDefinition.java
@@ -11,6 +11,8 @@ import java.util.Collections;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import jenkins.model.Jenkins;
 import net.sf.json.JSONObject;
 import org.json.JSONException;
 import org.kohsuke.stapler.DataBoundConstructor;
@@ -27,7 +29,7 @@ public class SauceParameterDefinition extends ParameterDefinition {
     private static final Logger logger = Logger.getLogger(SauceParameterDefinition.class.getName());
 
     /** Handles the retrieval of browsers from Sauce Labs. */
-    private static final BrowserFactory BROWSER_FACTORY = BrowserFactory.getInstance(new JenkinsSauceREST(null, null, DataCenter.US_WEST));
+    private static final BrowserFactory BROWSER_FACTORY = BrowserFactory.getInstance(new JenkinsSauceREST(null, null, DataCenter.US_WEST, Jenkins.get().getProxy()));
 
     @DataBoundConstructor
     public SauceParameterDefinition() {

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceParameterValue.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceParameterValue.java
@@ -17,7 +17,7 @@ import org.kohsuke.stapler.DataBoundConstructor;
 public class SauceParameterValue extends ParameterValue {
 
     /** Handles the retrieval of browsers from Sauce Labs. */
-    private static final BrowserFactory BROWSER_FACTORY = BrowserFactory.getInstance(new JenkinsSauceREST(null, null, DataCenter.US_WEST));
+    private static final BrowserFactory BROWSER_FACTORY = BrowserFactory.getInstance(new JenkinsSauceREST(null, null, DataCenter.US_WEST, null));
 
     private final String selectedBrowsersString;
 

--- a/src/main/java/hudson/plugins/sauce_ondemand/SauceTestResultsById.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/SauceTestResultsById.java
@@ -7,6 +7,8 @@ import hudson.plugins.sauce_ondemand.credentials.SauceCredentials;
 import java.io.IOException;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import jenkins.model.Jenkins;
 import org.json.JSONException;
 
 /** */
@@ -40,7 +42,10 @@ public class SauceTestResultsById {
         new JenkinsSauceREST(
             credentials.getUsername(),
             credentials.getPassword().getPlainText(),
-            DataCenter.fromString(credentials.getRestEndpointName())));
+            DataCenter.fromString(credentials.getRestEndpointName()),
+            Jenkins.get().getProxy()
+        )
+    );
   }
 
   public String getId() {

--- a/src/main/java/hudson/plugins/sauce_ondemand/credentials/SauceCredentials.java
+++ b/src/main/java/hudson/plugins/sauce_ondemand/credentials/SauceCredentials.java
@@ -21,6 +21,7 @@ import com.saucelabs.saucerest.api.AccountsEndpoint;
 import edu.umd.cs.findbugs.annotations.CheckForNull;
 import edu.umd.cs.findbugs.annotations.NonNull;
 import hudson.Extension;
+import hudson.ProxyConfiguration;
 import hudson.model.AbstractBuild;
 import hudson.model.AbstractDescribableImpl;
 import hudson.model.AbstractProject;
@@ -171,9 +172,9 @@ public class SauceCredentials extends BaseStandardCredentials implements Standar
         return getCredentialsById(build.getProject(), credentialId);
     }
 
-    public JenkinsSauceREST getSauceREST() {
+    public JenkinsSauceREST getSauceREST(ProxyConfiguration proxy) {
         DataCenter dc = DataCenter.fromString(getRestEndpointName());
-        JenkinsSauceREST sauceREST = new JenkinsSauceREST(getUsername(), getPassword().getPlainText(), dc);
+        JenkinsSauceREST sauceREST = new JenkinsSauceREST(getUsername(), getPassword().getPlainText(), dc, proxy);
         return sauceREST;
     }
 
@@ -193,7 +194,7 @@ public class SauceCredentials extends BaseStandardCredentials implements Standar
 
             DataCenter dc = DataCenter.fromString(dataCenter);
 
-            JenkinsSauceREST rest = new JenkinsSauceREST(username, value, dc);
+            JenkinsSauceREST rest = new JenkinsSauceREST(username, value, dc, Jenkins.get().getProxy());
             AccountsEndpoint users = rest.getAccountsEndpoint();
             // If unauthorized getUser returns an empty string.
             try {

--- a/src/test/java/hudson/plugins/sauce_ondemand/SauceBuildWrapperTest.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/SauceBuildWrapperTest.java
@@ -81,7 +81,7 @@ public class SauceBuildWrapperTest {
     this.credentialsId =
         SauceCredentials.migrateToCredentials("fakeuser", "fakekey", null, "unittest");
 
-    JenkinsSauceREST sauceRest = new JenkinsSauceREST("username", "access key", DataCenter.US_WEST);
+    JenkinsSauceREST sauceRest = new JenkinsSauceREST("username", "access key", DataCenter.US_WEST, null);
     PluginImpl plugin = PluginImpl.get();
     assertNotNull(plugin);
     // Reset connection string every run

--- a/src/test/java/hudson/plugins/sauce_ondemand/mocks/MockSauceREST.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/mocks/MockSauceREST.java
@@ -7,7 +7,7 @@ import java.net.URL;
 public class MockSauceREST extends JenkinsSauceREST {
 
   public MockSauceREST() {
-    super("fake", "", DataCenter.US_WEST);
+    super("fake", "", DataCenter.US_WEST, null);
   }
 
   public String retrieveResults(URL restEndpoint) {


### PR DESCRIPTION
<!-- Please describe your pull request here. -->

This PR https://github.com/jenkinsci/sauce-ondemand-plugin/pull/120 completely breaks the `sauce` step. 
It tries to access the `ProxyConfiguration` on an agent by retrieving it from the `Jenkins` instance which it is not available on agents.

The failure was:
```
14:43:52  java.lang.IllegalStateException: Jenkins.instance is missing. Read the documentation of Jenkins.getInstanceOrNull to see what you are doing wrong.
14:43:52  	at jenkins.model.Jenkins.get(Jenkins.java:819)
14:43:52  	at hudson.plugins.sauce_ondemand.JenkinsSauceREST.getJenkinsPluginHttpConfig(JenkinsSauceREST.java:54)
14:43:52  	at hudson.plugins.sauce_ondemand.JenkinsSauceREST.<init>(JenkinsSauceREST.java:33)
14:43:52  	at hudson.plugins.sauce_ondemand.credentials.SauceCredentials.getSauceREST(SauceCredentials.java:176)
14:43:52  	at com.saucelabs.jenkins.pipeline.SauceConnectStep$SauceStartConnectHandler.call(SauceConnectStep.java:171)
14:43:52  	at com.saucelabs.jenkins.pipeline.SauceConnectStep$SauceStartConnectHandler.call(SauceConnectStep.java:149)
14:43:52  	at hudson.remoting.UserRequest.perform(UserRequest.java:211)
14:43:52  	at hudson.remoting.UserRequest.perform(UserRequest.java:54)
14:43:52  	at hudson.remoting.Request$2.run(Request.java:377)
14:43:52  	at hudson.remoting.InterceptingExecutorService.lambda$wrap$0(InterceptingExecutorService.java:78)
14:43:52  	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
14:43:52  	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
14:43:52  	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
14:43:52  	at java.base/java.lang.Thread.run(Thread.java:833)
14:43:53  
```

Any data that is needed by an agent needs to be transferred in the `MasterToSlaveCallable` or in the `Step` to the `StepExecution`.

I'm not 100% sure I will have passed it through properly in all cases.


### Testing done

I've ran this build on our production Jenkins instance and sauce labs is now working
(this is our config / pipeline code: https://github.com/hmcts/cnp-jenkins-library/blob/e7a90577bae3c92d4b83558e7114a410a760419c/vars/withSauceConnect.groovy#L10-L15)

I have not ran it behind a proxy.

I tried quickly writing a test to reproduce this but I think it doesn't work in `JenkinsRule` and probably needs a more complicated `RealJenkinsRule` test written, which is do-able but would take more time.

<!-- Comment:
Provide a clear description of how this change was tested.
At minimum this should include proof that a computer has executed the changed lines.
Ideally this should include an automated test or an explanation as to why this change has no tests.
Note that automated test coverage is less than complete, so a successful PR build does not necessarily imply that a computer has executed the changed lines.
If automated test coverage does not exist for the lines you are changing, you must describe the scenario(s) in which you manually tested the change.
For frontend changes, include screenshots of the relevant page(s) before and after the change.
For refactoring and code cleanup changes, exercise the code before and after the change and verify the behavior remains the same.
-->

```[tasklist]
### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [x] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
```

<!--
Put an `x` into the [ ] to show you have filled the information.
The template comes from https://github.com/jenkinsci/.github/blob/master/.github/pull_request_template.md 
You can override it by creating .github/pull_request_template.md in your own repository 
-->
