### PR TITLE
Bump ci-sauce for SC 5 version check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
     <jenkins.baseline>2.452</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.4</jenkins.version>
-    <ci-sauce.version>2.0</ci-sauce.version>
+    <ci-sauce.version>2.1</ci-sauce.version>
     <saucerest.version>2.5.3</saucerest.version>
   </properties>
 

--- a/src/main/resources/hudson/plugins/sauce_ondemand/PluginImpl/help-sauceConnectDirectory.html
+++ b/src/main/resources/hudson/plugins/sauce_ondemand/PluginImpl/help-sauceConnectDirectory.html
@@ -1,3 +1,10 @@
 <div>
-    By default, we extract a bundled/tested version of Sauce Connect to your $HOME directory and run it. If you want to use an already installed version instead, specify its full path.
+    By default, we extract a bundled/tested version of Sauce Connect to your
+    $HOME directory and run it. If you want to use an already installed version
+    instead, specify its full path.
+
+    <br />
+
+    This option is also needed when "Use Latest Sauce Connect version" is
+    enabled.
 </div>

--- a/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper/help-useLatestSauceConnect.html
+++ b/src/main/resources/hudson/plugins/sauce_ondemand/SauceOnDemandBuildWrapper/help-useLatestSauceConnect.html
@@ -1,4 +1,13 @@
 <div>
-If this checkbox is selected, the plugin will always check for and use the latest version of <a href="https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy">Sauce Connect</a>
+    If this checkbox is selected, the plugin will always check for and use the
+    latest version of
+    <a href="https://wiki.saucelabs.com/display/DOCS/Sauce+Connect+Proxy"
+        >Sauce Connect</a
+    >
 
+    <br />
+
+    Note: A download directory must also be set in "Manage Jenkins &gt; System
+    &gt; Sauce Support &gt; Override Sauce Connect Path" to download the latest
+    version.
 </div>


### PR DESCRIPTION
ci-sauce 2.1 supports downloading the latest SC 5 binaries.