### PR TITLE
bugfix: Fix tunnels closing for Pipelines projects

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -14,7 +14,7 @@
     <!-- Baseline Jenkins version you use to build the plugin. Users must have this version or newer to run. -->
     <jenkins.baseline>2.452</jenkins.baseline>
     <jenkins.version>${jenkins.baseline}.4</jenkins.version>
-    <ci-sauce.version>2.3</ci-sauce.version>
+    <ci-sauce.version>2.6</ci-sauce.version>
     <saucerest.version>2.5.3</saucerest.version>
   </properties>
 
@@ -169,6 +169,11 @@
           <artifactId>slf4j-jdk14</artifactId>
         </exclusion>
       </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>com.saucelabs</groupId>

--- a/src/main/java/com/saucelabs/jenkins/pipeline/SauceConnectStep.java
+++ b/src/main/java/com/saucelabs/jenkins/pipeline/SauceConnectStep.java
@@ -1,7 +1,5 @@
 package com.saucelabs.jenkins.pipeline;
 
-import static com.saucelabs.jenkins.pipeline.SauceConnectStep.SauceConnectStepExecution.getSauceTunnelManager;
-
 import com.cloudbees.plugins.credentials.common.StandardUsernameListBoxModel;
 import com.saucelabs.ci.sauceconnect.AbstractSauceTunnelManager;
 import com.saucelabs.ci.sauceconnect.SauceConnectManager;
@@ -63,6 +61,10 @@ public class SauceConnectStep extends Step {
         this.sauceConnectPath = Util.fixEmptyAndTrim(sauceConnectPath);
         this.options = StringUtils.trimToEmpty(options);
         this.optionsSC5 = StringUtils.trimToEmpty(optionsSC5);
+    }
+
+    public static SauceConnectManager getSauceTunnelManager() {
+        return HudsonSauceManagerFactory.getInstance().createSauceConnectManager();
     }
 
     @Override
@@ -334,7 +336,7 @@ public class SauceConnectStep extends Step {
 
             body = getContext().newBodyInvoker()
                 .withContext(EnvironmentExpander.merge(getContext().get(EnvironmentExpander.class), new ExpanderImpl(overrides)))
-                .withCallback(new Callback(sauceCredentials, options, proxy))
+                .withCallback(new Callback(sauceCredentials, combinedOptions, proxy))
                 .withDisplayName("Sauce Connect")
                 .start();
 
@@ -347,10 +349,6 @@ public class SauceConnectStep extends Step {
                 body.cancel(cause);
             }
 
-        }
-
-        public static SauceConnectManager getSauceTunnelManager() {
-            return HudsonSauceManagerFactory.getInstance().createSauceConnectManager();
         }
 
         private static final class Callback extends BodyExecutionCallback.TailCall {

--- a/src/test/java/hudson/plugins/sauce_ondemand/ExtractSauceConnectTest.java
+++ b/src/test/java/hudson/plugins/sauce_ondemand/ExtractSauceConnectTest.java
@@ -4,6 +4,7 @@ import com.saucelabs.ci.sauceconnect.SauceConnectManager;
 import java.io.File;
 import org.junit.Before;
 import org.junit.Test;
+import org.slf4j.helpers.NOPLogger;
 
 /**
  * @author Ross Rowe
@@ -20,11 +21,11 @@ public class ExtractSauceConnectTest {
     @Test
     public void linux() throws Exception {
         File workingDirectory = new File(System.getProperty("java.io.tmpdir"));
-        manager.extractZipFile(workingDirectory, SauceConnectManager.OperatingSystem.LINUX_AMD64);
+        manager.extractZipFile(workingDirectory, SauceConnectManager.OperatingSystem.LINUX_AMD64, NOPLogger.NOP_LOGGER);
     }
 
     @Test
     public void windows() throws Exception {
-        manager.extractZipFile(new File(System.getProperty("java.io.tmpdir")), SauceConnectManager.OperatingSystem.WINDOWS_AMD64);
+        manager.extractZipFile(new File(System.getProperty("java.io.tmpdir")), SauceConnectManager.OperatingSystem.WINDOWS_AMD64, NOPLogger.NOP_LOGGER);
     }
 }


### PR DESCRIPTION
SC-5334

This is a bugfix for using the plugin with Pipelines project. The problem was that autogenerated name (option) wasn't propagated to the code responsible for closing the tunnel, so it wasn't able to find the tunnel Process.

That wasn't the case for Freestyle projects, the implementation was correct there.

To troubleshoot the issue more accurately, the ci-sauce library has been bumped because it logs more information.

### Testing done

- Built the plugin locally, uploaded to local Jenkins instance and run some jobs

### Submitter checklist
- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your main branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [x] Link to relevant issues in GitHub or Jira
- [ ] (NOT APPLICABLE) Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests that demonstrate the feature works or the issue is fixed
